### PR TITLE
re add maintenance mode statement

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -97,6 +97,7 @@ font_awesome_version = "5.9.0"
 
 notification = """
 📣 **This is the new website for Flux version 2 and GitOps Toolkit, currently in active development.** If you are looking for the Flux v1 documentation, **[please click here](https://docs.fluxcd.io)**.<br /><br />
+📣 **[Flux v1 is in maintenance mode](https://github.com/fluxcd/flux/issues/3320)!** We will soon start publishing guides which help you migrate Flux v2 and the GitOps Toolkit.<br /><br />
 🎉 **[Flagger](https://flagger.app) is now officially a Flux project.** This is another great step for Flux to become the family of GitOps projects.
 """
 


### PR DESCRIPTION
@mewzherder rightly pointed out that the statement about maintenance mode went missing.

I realise that the "notification area" is getting very crowded now. Maybe we just merge this as is for now and then figure out a way have a news section that sources bits from somewhere else and takes up more clearly defined space, e.g. 3 stickied bits of info (like flagger-move, maintenance mode) plus the last 3 blogs posts...?