### PR TITLE
create proper sub-pages for contributing, governance and security

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -51,27 +51,21 @@ url = "https://github.com/fluxcd/community/blob/main/CODE_OF_CONDUCT.md"
 weight = 1
 
 [[menus.main]]
-name = "Community"
-parent = "project"
-url = "https://github.com/fluxcd/community/blob/main/COMMUNITY.md"
-weight = 20
-
-[[menus.main]]
 name = "Contributing"
 parent = "project"
-url = "https://github.com/fluxcd/community/blob/main/CONTRIBUTING.md"
+url = "/contributing"
 weight = 30
 
 [[menus.main]]
 name = "Governance"
 parent = "project"
-url = "https://github.com/fluxcd/community/blob/main/GOVERNANCE.md"
+url = "/governance"
 weight = 40
 
 [[menus.main]]
 name = "Security"
 parent = "project"
-url = "https://github.com/fluxcd/community/blob/main/SECURITY.md"
+url = "/security"
 weight = 50
 
 [[menus.main]]

--- a/content/en/.gitignore
+++ b/content/en/.gitignore
@@ -1,1 +1,5 @@
 community.md
+contributing.md
+governance.md
+security.md
+support.md

--- a/external-sources/fluxcd/community
+++ b/external-sources/fluxcd/community
@@ -1,2 +1,5 @@
 "/README.md","/community.md"
 "/SUPPORT.md","/support.md"
+"/CONTRIBUTING.md","/contributing.md"
+"/GOVERNANCE.md","/governance.md"
+"/SECURITY.md","/security.md"


### PR DESCRIPTION
This will give us `/security`, `/governance`, `/contributing`, as opposed to linking off to the `/f/community` repository.