### PR TITLE
Unset github_subdir - we pass 'en' in contentDir

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -57,7 +57,6 @@ enable = false
 description          = "Open and extensible continuous delivery solution for Kubernetes."
 copyright            = "The Flux authors"
 github_repo  		 = "https://github.com/fluxcd/website"
-github_subdir	     = "en"
 github_branch		 = "main"
 github_project_repo  = "https://github.com/fluxcd/flux2"
 slack                = "https://cloud-native.slack.com/messages/flux"


### PR DESCRIPTION
This fixes (most of) the sidebar links. See #121 for the remaining work.

Fixes: #140