### PR TITLE
Update helmreleases.md

### DIFF
--- a/content/en/docs/guides/helmreleases.md
+++ b/content/en/docs/guides/helmreleases.md
@@ -138,7 +138,7 @@ for details about how to use other storage backends.
 
 ```yaml
 apiVersion: source.toolkit.fluxcd.io/v1beta1
-kind: HelmRepository
+kind: HelmRelease
 metadata:
   name: chartmuseum
   namespace: flux-system


### PR DESCRIPTION

Hi, I believe, at https://fluxcd.io/docs/guides/helmreleases/#cloud-storage , I believe that you have a typo:  I think that it's a `FluxCD` `HelmRelease`, to helm release Chartmuseum, not a `HelmRepository`, see proposed change


Thank you very much fo he work done on the 2nd generation of `FluxCD` (btw, I did not find where the "gitops engine" common project with Argo CD is... any link ?)
