### PR TITLE
Exclude navbar search on /blog/ and /docs/

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -31,6 +31,14 @@
 			{{ end }}
 		{{ end }}
 
+		{{ $url := urls.Parse .Permalink }}
+		{{ if lt (len $url.Path) 6 }}
 		<li class="nav-item nav-search-item">{{ partial "search-input.html" . }}</li>
+		{{ else }}
+		{{ $path := slicestr $url.Path 0 6 }}
+		{{ if and (ne $path "/docs/") (ne $path "/blog/") }}
+		<li class="nav-item nav-search-item">{{ partial "search-input.html" . }}</li>
+		{{ end }}
+		{{ end }}
 	</ul>
 </nav>


### PR DESCRIPTION
Fixes: #173

I'm sure there are prettier ways to do this. Maybe somebody can illuminate me on how to do this in a more compact way.