### PR TITLE
Update monitoring docs to kube-prometheus-stack

### DIFF
--- a/content/en/docs/guides/monitoring.md
+++ b/content/en/docs/guides/monitoring.md
@@ -59,7 +59,7 @@ flux create kustomization monitoring-config \
 You can access Grafana using port forwarding:
 
 ```sh
-kubectl -n flux-system port-forward svc/monitory-grafana 3000:80
+kubectl -n flux-system port-forward svc/kube-prometheus-stack-grafana 3000:80
 ```
 
 ## Grafana dashboards

--- a/content/en/docs/guides/monitoring.md
+++ b/content/en/docs/guides/monitoring.md
@@ -37,8 +37,8 @@ flux create kustomization monitoring-stack \
   --prune=true \
   --source=monitoring \
   --path="./manifests/monitoring/kube-prometheus-stack" \
-  --health-check="Deployment/monitoring-kube-prometheus-operator.flux-system" \
-  --health-check="Deployment/monitoring-grafana.flux-system"
+  --health-check="Deployment/kube-prometheus-stack-operator.monitoring" \
+  --health-check="Deployment/kube-prometheus-stack-grafana.monitoring"
 ```
 
 ## Create `PodMonitor` and configmap for Grafana dashboards
@@ -53,9 +53,7 @@ flux create kustomization monitoring-config \
   --interval=1h \
   --prune=true \
   --source=monitoring \
-  --path="./manifests/monitoring/monitoring-config" \
-  --health-check="Deployment/monitoring-kube-prometheus-operator.flux-system" \
-  --health-check="Deployment/monitoring-grafana.flux-system"
+  --path="./manifests/monitoring/monitoring-config"
 ```
 
 You can access Grafana using port forwarding:

--- a/content/en/docs/guides/monitoring.md
+++ b/content/en/docs/guides/monitoring.md
@@ -32,7 +32,7 @@ Then apply the [manifests/monitoring/kube-prometheus-stack](https://github.com/f
 kustomization:
 
 ```sh
-flux create kustomization monitoring \
+flux create kustomization monitoring-stack \
   --interval=1h \
   --prune=true \
   --source=monitoring \
@@ -49,7 +49,7 @@ When using Prometheus Operator you need a `PodMonitor` object to configure scrap
 Apply the [manifests/monitoring/monitoring-config](https://github.com/fluxcd/flux2/tree/main/manifests/monitoring/monitoring-config) kustomization:
 
 ```sh
-flux create kustomization monitoring \
+flux create kustomization monitoring-config \
   --interval=1h \
   --prune=true \
   --source=monitoring \

--- a/content/en/docs/guides/monitoring.md
+++ b/content/en/docs/guides/monitoring.md
@@ -10,12 +10,14 @@ card:
 
 This guide walks you through configuring monitoring for the Flux control plane.
 
-Flux uses kube-prometheus-stack to provide a monitoring stack:
-The
-* **Prometheus Operator** - collects metrics from the toolkit controllers and stores them for 2h
-* **Grafana** dashboards - displays the control plane resource usage and reconciliation stats
+Flux uses [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) to provide a monitoring stack:
 
-## Install the kube-prometheus-operator
+The kube-promethus stack installs:
+* **Prometheus** server - collects metrics from the toolkit controllers
+* **Grafana** dashboards - displays the control plane resource usage and reconciliation stats
+* **kube-state-metrics** -  generates metrics about the state of the objects from API server
+
+## Install the kube-prometheus-stack
 
 To install the monitoring stack with `flux`, first register the toolkit Git repository on your cluster:
 


### PR DESCRIPTION
Documents [flux2#1399](https://github.com/fluxcd/flux2/pull/1399) which is the move from our monitoring stack to [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)