### PR TITLE
hide the description on doc pages

### DIFF
--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -87,3 +87,9 @@ h2.section-label {
   font-weight: 600;
   margin-bottom: 1rem;
 }
+
+.td-content {
+  div.lead  {
+    display: none;
+  }
+}


### PR DESCRIPTION
attempt to address

fix: #235