### PR TITLE
Darker color for info blocks

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -28,6 +28,8 @@ $secondary: $flux-light-blue;
 $dark: $flux-black;
 $blue: $flux-dark-blue;
 
+$info: #19b27f;
+
 $google_font_name: "Montserrat";
 $google_font_family: "Montserrat:300,300i,400,400i,600,600i,700,700i";
 


### PR DESCRIPTION
Before

![Screen Shot 2021-05-11 at 08 45 09](https://user-images.githubusercontent.com/19580905/117778115-32c95c00-b235-11eb-8f66-dc2462512fb6.png)

After

![Screen Shot 2021-05-11 at 08 44 41](https://user-images.githubusercontent.com/19580905/117778071-280ec700-b235-11eb-8782-9f67d73e5ce2.png)

Signed-off-by: Alison Dowdney <alison@alisondowdney.com>