### PR TITLE
Remove user-specific files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,3 @@ static/install.sh
 
 # Adopters logos
 static/img/logos
-
-# Editors
-.vscode
-
-# Mac specific things
-.DS_Store


### PR DESCRIPTION
Fixes: #248

Refer to https://gist.github.com/subfuzion/db7f57fff2fb6998a16c or other for a global `gitignore` file.