### PR TITLE
Remove "Flux v2" mentions

### DIFF
--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -1,5 +1,5 @@
 ---
-title: "Get Started with Flux v2"
+title: "Get Started with Flux"
 linkTitle: "Get Started"
 description: "Get Started with Flux and the GitOps Toolkit."
 weight: 20

--- a/external-sources/fluxcd/flux2
+++ b/external-sources/fluxcd/flux2
@@ -1,1 +1,1 @@
-"/CONTRIBUTING.md","/docs/contributing/flux2.md","Contributing to Flux v2"
+"/CONTRIBUTING.md","/docs/contributing/flux.md","Contributing to Flux"

--- a/static/_redirects
+++ b/static/_redirects
@@ -5,3 +5,4 @@
 /docs/components/source/controller          /docs/components/source         301!
 /docs/guides/installation                   /docs/installation              301!
 /contributing                               /docs/contributing              301!
+/docs/contributing/flux2                    /docs/contributing/flux         301!


### PR DESCRIPTION
- In title 'Get Started' guide
- In contributing document
