### PR TITLE
Don't show right sidebar if "hugeTable: true" is set

### DIFF
--- a/content/en/docs/migration/timetable.md
+++ b/content/en/docs/migration/timetable.md
@@ -11,12 +11,6 @@ Its purpose is to help improve your experience in deciding how and when to plan 
 Please refer to the [Roadmap]({{< relref "../roadmap/_index.md" >}}) for additional details.
 {{% /alert %}}
 
-<!-- Note: this div allows us to set fixed column widths in custom.css -->
-<!-- See: https://github.com/squidfunk/mkdocs-material/issues/118 -->
-<div markdown="1" class="timetable-explicit-col-widths">
-
-<!-- Requires mkdocs markdown_extensions footnotes and pymdownx.caret -->
-<!-- markdownlint-disable-file MD033 -->
 | Date | Flux 1 | Flux 2 CLI | GOTK[^1] |
 | -- | -- | -- | -- |
 | Oct 6, 2020 | [Maintenance Mode](https://github.com/fluxcd/website/pull/25)<br><ul><li>Flux 1 releases only include critical bug fixes (which don’t require changing Flux 1 architecture), and security patches (for OS packages, Go runtime, and kubectl). No new features</li><li>Existing projects encouraged to test migration to Flux 2 pre-releases in non-production</li></ul> | Development Mode<br><ul><li>Working to finish parity with Flux 1</li><li>New projects encouraged to test Flux 2 pre-releases in non-production</li></ul> | All Alpha[^2] |
@@ -25,8 +19,6 @@ Feb 18, 2021 | Partial Migration Mode<br><ul><li>Existing projects encouraged to
 | TBD | Migration and security support only<br><ul><li>Flux 1 releases only include security patches (no bug fixes)</li><li>Maintainers support users with migration to Flux 2 only, no longer with Flux 1 issues</li><li>Flux 1 archive date announced</li></ul> | Public release (GA), Production Ready<br><ul><li>CLI commits to backwards compatibility moving forward</li><li>CLI follows kubectl style backwards compatibility support: +1 -1 MINOR version for server components (e.g., APIs, Controllers, validation webhooks)</li></ul> | All Beta, Production Ready |
 | TBD | Archived<br><ul><li>Flux 1 obsolete, no further releases or maintainer support</li><li>Flux 1 repo archived</li></ul> | Continued active development | Continued active development |
 
-<!-- end .timetable-explicit-col-widths -->
-</div>
 
 [^1]: GOTK is shorthand for the [GitOps Toolkit](/docs/components/) APIs and Controllers
 

--- a/content/en/docs/migration/timetable.md
+++ b/content/en/docs/migration/timetable.md
@@ -3,6 +3,7 @@ title: "Timetable"
 linkTitle: "Migration and Support Timetable"
 description: "Flux v1 to v2 migration and support timetable."
 weight: 5
+hugeTable: true
 ---
 
 {{% alert color="info" title="💖 Flux Migration Commitment" %}}

--- a/hack/import-flux2-assets.sh
+++ b/hack/import-flux2-assets.sh
@@ -60,8 +60,10 @@ controller_version() {
 
 gen_crd_doc() {
   URL="$1"
-  TMP="$(mktemp)"
   DEST="$2"
+  HUGETABLE="$3"
+
+  TMP="$(mktemp)"
   curl -# -Lf "$URL" > "$TMP"
 
   # Ok, so this section is not pretty, but we have a number of issues we need to look at here:
@@ -87,6 +89,9 @@ gen_crd_doc() {
       echo "title: $TITLE"
       echo "description: The GitOps Toolkit Custom Resource Definitions documentation."
       echo "importedDoc: true"
+      if [ -n "$HUGETABLE" ]; then
+        echo "hugeTable: true"
+      fi
       echo "---"
     } >> "$DEST"
     grep -vE "^<!--" "$TMP" |sed '1d' >> "$DEST"
@@ -99,7 +104,7 @@ gen_crd_doc() {
 {
   # source-controller CRDs
   SOURCE_VER="$(controller_version source-controller)"
-  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/source-controller/$SOURCE_VER/docs/api/source.md" "$COMPONENTS_DIR/source/api.md"
+  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/source-controller/$SOURCE_VER/docs/api/source.md" "$COMPONENTS_DIR/source/api.md" "HUGETABLE"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/source-controller/$SOURCE_VER/docs/spec/v1beta1/gitrepositories.md" "$COMPONENTS_DIR/source/gitrepositories.md"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/source-controller/$SOURCE_VER/docs/spec/v1beta1/helmrepositories.md" "$COMPONENTS_DIR/source/helmrepositories.md"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/source-controller/$SOURCE_VER/docs/spec/v1beta1/helmcharts.md" "$COMPONENTS_DIR/source/helmcharts.md"
@@ -109,14 +114,14 @@ gen_crd_doc() {
 {
   # kustomize-controller CRDs
   KUSTOMIZE_VER="$(controller_version kustomize-controller)"
-  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/kustomize-controller/$KUSTOMIZE_VER/docs/api/kustomize.md" "$COMPONENTS_DIR/kustomize/api.md"
+  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/kustomize-controller/$KUSTOMIZE_VER/docs/api/kustomize.md" "$COMPONENTS_DIR/kustomize/api.md" "HUGETABLE"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/kustomize-controller/$KUSTOMIZE_VER/docs/spec/v1beta1/kustomization.md" "$COMPONENTS_DIR/kustomize/kustomization.md"
 }
 
 {
   # helm-controller CRDs
   HELM_VER="$(controller_version helm-controller)"
-  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/helm-controller/$HELM_VER/docs/api/helmrelease.md" "$COMPONENTS_DIR/helm/api.md"
+  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/helm-controller/$HELM_VER/docs/api/helmrelease.md" "$COMPONENTS_DIR/helm/api.md" "HUGETABLE"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/helm-controller/$HELM_VER/docs/spec/v2beta1/helmreleases.md" "$COMPONENTS_DIR/helm/helmreleases.md"
 }
 
@@ -133,12 +138,12 @@ gen_crd_doc() {
 {
   # image-*-controller CRDs; these use the same API group
   IMG_REFL_VER="$(controller_version image-reflector-controller)"
-  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/api/image-reflector.md" "$COMPONENTS_DIR/image/reflector-api.md"
+  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/api/image-reflector.md" "$COMPONENTS_DIR/image/reflector-api.md" "HUGETABLE"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha2/imagerepositories.md" "$COMPONENTS_DIR/image/imagerepositories.md"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1alpha2/imagepolicies.md" "$COMPONENTS_DIR/image/imagepolicies.md"
 
   IMG_AUTO_VER="$(controller_version image-automation-controller)"
-  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/api/image-automation.md" "$COMPONENTS_DIR/image/automation-api.md"
+  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/api/image-automation.md" "$COMPONENTS_DIR/image/automation-api.md" "HUGETABLE"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/spec/v1alpha2/imageupdateautomations.md" "$COMPONENTS_DIR/image/imageupdateautomations.md"
 }
 

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}" class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </div>
+          {{ if not .Params.hugeTable }}
+          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
+            {{ partial "toc.html" . }}
+          </div>
+          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          {{ else }}
+          <main class="col-12 col-md-12 col-xl-10 pl-md-5 " role="main">
+          {{ end }}
+            {{ partial "version-banner.html" . }}
+            {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>


### PR DESCRIPTION
Fixes: #178 

Modify import script for this. Docs layout as well, notable diff to `docsy` is:

```diff
--- themes/docsy/layouts/docs/baseof.html	2021-04-28 16:57:40.000000000 +0200
+++ layouts/docs/baseof.html	2021-05-25 17:07:32.433230910 +0200
@@ -13,10 +13,14 @@
           <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
           </div>
+          {{ if not .Params.hugeTable }}
           <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
             {{ partial "toc.html" . }}
           </div>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          {{ else }}
+          <main class="col-12 col-md-12 col-xl-10 pl-md-5 " role="main">
+          {{ end }}
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}
```