### PR TITLE
Update image-update.md to allow secret creation

### DIFF
--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -723,7 +723,7 @@ spec:
                 --dry-run=client \
                 --docker-server="$ECR_REGISTRY" \
                 --docker-username=AWS \
-                --docker-password="$(</token/ecr-token)"
+                --docker-password="$(</token/ecr-token)" \
                 -o yaml | kubectl apply -f -
 ```
 


### PR DESCRIPTION
Patch the current documentation to allow continuation of line where required to create the docker-registry secret in the example.  Without this the example will not run due to a bash error.  

Output of error this fixes:

```
secret/ecr-credentials created (dry run)
/bin/bash: line 5: -o: command not found
error: no objects passed to apply
```