### PR TITLE
Front page color improvements

### DIFF
--- a/assets/scss/_buttons.scss
+++ b/assets/scss/_buttons.scss
@@ -11,3 +11,52 @@
         }
     }
 }
+
+
+@mixin projects-btn-primary {
+  a.btn-primary {
+    background-color: rgba($flux-darkest-blue, 0.5);
+    border-color: $flux-darkest-blue $flux-darkest-blue $flux-black $flux-black !important;
+    margin-right: 1rem;
+    padding-left: 1rem;
+
+    &:hover {
+      background-color: rgba($flux-darkest-blue, 0.7) !important;
+      box-shadow: none !important;
+    }
+
+    &:active {
+      background-color: $flux-light-blue !important;
+      box-shadow: none !important;
+    }
+
+    &:focus {
+      box-shadow: none !important;
+    }
+  }
+}
+
+@mixin projects-btn-secondary {
+  a.btn-secondary {
+    color: $flux-gray;
+    background-color: rgba($flux-light-blue, 1);
+    border-color: $flux-gray $flux-gray $flux-light-gray $flux-light-gray !important;
+    margin-right: 1rem;
+    padding-left: 1rem;
+
+    &:hover {
+      // color: $flux-lighter-blue;
+      background-color: rgba($flux-light-blue, 0.7) !important;
+      box-shadow: none !important;
+    }
+
+    &:active {
+      background-color: $flux-light-blue !important;
+      box-shadow: none !important;
+    }
+
+    &:focus {
+      box-shadow: none !important;
+    }
+  }
+}

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -1,5 +1,3 @@
-
-
 .features, .resources {
   .col-lg-4 {
     margin: 2rem 0rem !important;
@@ -36,6 +34,13 @@
 .flux-other-projects {
   section {
     margin: 0 auto;
+  }
+}
+
+.section-resources {
+  .td-box {
+    background-color: #2f2f2f;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cpath fill='%234f4f4f' fill-opacity='0.43' d='M1 3h1v1H1V3zm2-2h1v1H3V1z'%3E%3C/path%3E%3C/svg%3E");
   }
 }
 

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -1,3 +1,23 @@
+@mixin white-background-a {
+  a {
+    color: $flux-lighter-blue !important;
+
+    &:hover {
+      color: $flux-darkest-blue !important;
+    }
+  }
+}
+
+@mixin gray-background-a {
+  a {
+    color: $flux-light-blue !important;
+
+    &:hover {
+      color: $flux-dark-blue !important;
+    }
+  }
+}
+
 .features, .resources {
   .col-lg-4 {
     margin: 2rem 0rem !important;
@@ -19,6 +39,8 @@
   .fas, .fab, .fa {
     color: $flux-dark-blue;
   }
+
+  @include white-background-a;
 }
 
 .resources {
@@ -59,11 +81,22 @@ h2.section-label {
     border-top-color: $flux-dark-blue;
   }
 
+  .-bg-blue {
+    @include projects-btn-primary;
+    @include projects-btn-secondary;
+  }
+
   .-bg-green {
     background-color: $flux-green;
+    
+    @include projects-btn-primary;
+    @include projects-btn-secondary;
+  }
+
+  .-bg-white {
+    @include white-background-a;
   }
 }
-
 
 .section-community {
   background-color: $flux-gray;
@@ -91,5 +124,10 @@ h2.section-label {
   h2.section-label {
     margin: 1rem 0 2rem 0;
   }
+
+  @include gray-background-a;
 }
 
+.cncf-footer {
+  @include white-background-a;
+}

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -31,20 +31,43 @@
   }
 }
 
-.flux-other-projects {
-  section {
-    margin: 0 auto;
+h2.section-label {
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.td-content {
+  div.lead  {
+    display: none;
   }
 }
 
+
 .section-resources {
   .td-box {
-    background-color: #2f2f2f;
+    background-color: $flux-gray;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cpath fill='%234f4f4f' fill-opacity='0.43' d='M1 3h1v1H1V3zm2-2h1v1H3V1z'%3E%3C/path%3E%3C/svg%3E");
   }
 }
 
+.section-other-flux-projects {
+  section.td-box--6 {
+    background-color: $flux-dark-blue;
+  }
+
+  .td-arrow-down::before {
+    border-top-color: $flux-dark-blue;
+  }
+
+  .-bg-green {
+    background-color: $flux-green;
+  }
+}
+
+
 .section-community {
+  background-color: $flux-gray;
+
   section.row.td-box {
     padding-top: 1.5rem;
   }
@@ -64,15 +87,9 @@
   p > a {
     font-size: 1.5rem;
   }
-}
 
-h2.section-label {
-  font-weight: 600;
-  margin-bottom: 1rem;
-}
-
-.td-content {
-  div.lead  {
-    display: none;
+  h2.section-label {
+    margin: 1rem 0 2rem 0;
   }
 }
+

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -20,13 +20,17 @@ $flux-dark-blue: #3d6ddd;
 $flux-lighter-blue: #5f86e3;
 $flux-light-blue: #c3d2f4;
 
+$flux-green: #3eaf7c;
+
 $flux-black: #1a1a1a;
 $flux-white: #ffffff;
+$flux-gray: #2f2f2f;
 
 $primary: $flux-dark-blue;
 $secondary: $flux-light-blue;
 $dark: $flux-black;
 $blue: $flux-dark-blue;
+
 
 $info: #19b27f;
 

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -25,6 +25,7 @@ $flux-green: #3eaf7c;
 $flux-black: #1a1a1a;
 $flux-white: #ffffff;
 $flux-gray: #2f2f2f;
+$flux-light-gray: #5f5f5f;
 
 $primary: $flux-dark-blue;
 $secondary: $flux-light-blue;

--- a/assets/scss/blocks/_hero.scss
+++ b/assets/scss/blocks/_hero.scss
@@ -76,9 +76,17 @@
   }
 
   a.btn {
-    color: $flux-black !important;
+    margin-top: 1rem;
+    
+    color: $flux-white !important;
     font-style: normal;
     font-weight: 600;
-    background-color: $flux-light-blue;
+    font-size: 1.5rem;
+    background-color: $flux-darkest-blue;
+    border-color: $flux-black !important;
+    &:active {
+      background-color: $flux-light-blue !important;
+      box-shadow: none !important;
+    }
   }
 }

--- a/assets/scss/blocks/_hero.scss
+++ b/assets/scss/blocks/_hero.scss
@@ -27,9 +27,13 @@
 }
 
 .lead-gitops section {
-  // border-top: 1px dotted rgb(150,150,200);
   padding: 0rem 0 2rem 0 !important;
   background: none;
+
+
+  a[aria-hidden="true"] {
+    display: none;
+  }
 
   .td-arrow-down {
     &::before {
@@ -62,6 +66,8 @@
   }
   h1 {
     color: rgba($flux-white, 0.95);
+    text-shadow: -1px 1px $flux-gray;
+
   }
   h2 {
     color: rgba($flux-white, 0.95);
@@ -71,22 +77,26 @@
   }
   a {
     color: $flux-light-blue !important;
-    font-weight: 300;
+    font-weight: 400;
     font-style: italic;
+
+    &:hover {
+      color: $flux-darkest-blue !important;
+      text-shadow: -1px 1px $flux-lighter-blue;
+    }
   }
 
   a.btn {
     margin-top: 1rem;
     
     color: $flux-white !important;
-    text-shadow: 4px 2px $flux-gray;
+    text-shadow: -2px 1px $flux-gray;
     
     font-style: normal;
     font-weight: 600;
     font-size: 1.5rem;
     background-color: $flux-darkest-blue;
-    border-color: $flux-black !important;
-    // border-color: $flux-white !important;
+    border-color: $flux-darkest-blue $flux-darkest-blue $flux-black $flux-black !important;
 
     &:hover {
       background-color: rgba($flux-darkest-blue, 0.7) !important;
@@ -95,6 +105,10 @@
 
     &:active {
       background-color: $flux-light-blue !important;
+      box-shadow: none !important;
+    }
+
+    &:focus {
       box-shadow: none !important;
     }
   }

--- a/assets/scss/blocks/_hero.scss
+++ b/assets/scss/blocks/_hero.scss
@@ -79,11 +79,20 @@
     margin-top: 1rem;
     
     color: $flux-white !important;
+    text-shadow: 4px 2px $flux-gray;
+    
     font-style: normal;
     font-weight: 600;
     font-size: 1.5rem;
     background-color: $flux-darkest-blue;
     border-color: $flux-black !important;
+    // border-color: $flux-white !important;
+
+    &:hover {
+      background-color: rgba($flux-darkest-blue, 0.7) !important;
+      box-shadow: none !important;
+    }
+
     &:active {
       background-color: $flux-light-blue !important;
       box-shadow: none !important;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,8 +1,8 @@
 @import "variables_project";
 @import "../../themes/docsy/assets/scss/main.scss";
+@import "buttons";
 @import "blocks/blocks";
 @import "adopters";
 @import "page";
 @import "index";
-@import "buttons";
 @import "terminal";

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -124,14 +124,14 @@ In this 5 video series, Geert Baeke takes a deep dive of Flux v2 and the use of 
 </div>
 
 <!-- OTHER FLUX PROJECTS -->
-
+<div class="section-other-flux-projects">
 {{< blocks/lead >}}
 
 <h2 class="section-label">Other Flux projects</h2>
 
 {{< /blocks/lead >}}
 
-{{% blocks/section type="flux-other-projects" color="white" %}}
+{{% blocks/section color="white" %}}
 
 {{% blocks/project title="GitOps Toolkit"
   image="/img/building-blocks.svg" image-align="left" bg-color="blue"
@@ -159,10 +159,10 @@ We **strongly advise** everyone to familiarise themselves with the latest versio
 {{% /blocks/project %}}
 
 {{% /blocks/section %}}
-
+</div>
 
 <!-- Community -->
-
+<div class="section-community">
 {{< blocks/lead color="dark" >}}
 
 <h2 class="section-label">Community</h2>
@@ -171,8 +171,8 @@ The Flux project aspires to be the vendor-neutral home for GitOps in a Cloud Nat
 What we achieved up until today is only possible because of our community.
 {{< /blocks/lead >}}
 
-<div class="section-community">
-{{< blocks/section color="dark" type="community">}}
+
+{{< blocks/section color="dark" type="abc_community">}}
 
 {{< blocks/feature icon="fab fa-github fa-2x" title="GitHub Discussions" url="https://github.com/fluxcd/flux2/discussions" >}}
 Join the conversation in GitHub Discussions. Everything Flux v2 related ranging from specificiations and feature planning to Show & Tell happens here.
@@ -180,6 +180,8 @@ Join the conversation in GitHub Discussions. Everything Flux v2 related ranging 
 <div class="join-github">
 Join the discussion today!
 </div>
+
+
 {{< /blocks/feature >}}
 
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -150,7 +150,7 @@ The canary analysis can be extended with webhooks for running system integration
 {{% /blocks/project %}}
 
 {{% blocks/project title="Flux v1 and Helm Operator"
-  image="/img/logos/flux-horizontal-color.png" image-align="right" bg-color="black"
+  image="/img/logos/flux-horizontal-color.png" image-align="right" bg-color="white"
   button1-url="https://docs.fluxcd.io/" button1-caption="Flux v1 Documentation" button1-color="blue"
   button2-url="https://docs.fluxcd.io/projects/helm-operator/" button2-caption="Helm Operator Documentation" button2-color="blue" %}}
 We owe our success and good reputation as GitOps project to Flux and Helm Operator. They are the v1 iteration of our project and currently in [maintenance mode](https://github.com/fluxcd/flux/issues/3320).
@@ -208,3 +208,4 @@ Join the mailing list!
 </div>
 
 {{< blocks/cncf >}}
+

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -81,6 +81,7 @@ to extend Flux.
 If you are new to Flux, you might want to check out some of the following resources to get started.
 {{< /blocks/lead >}}
 
+<div class="section-resources">
 {{% blocks/section type="resources" %}}
 
 {{% blocks/resource
@@ -120,6 +121,7 @@ In this 5 video series, Geert Baeke takes a deep dive of Flux v2 and the use of 
 {{% /blocks/resource %}}
 
 {{% /blocks/section %}}
+</div>
 
 <!-- OTHER FLUX PROJECTS -->
 

--- a/layouts/shortcodes/blocks/cncf.html
+++ b/layouts/shortcodes/blocks/cncf.html
@@ -1,7 +1,7 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 {{ $blockID := printf "td-cover-block-%d" .Ordinal }}
 {{ $logo := printf "img/logos/%s" site.Params.logos.cncf | relURL }}
-<section id="{{ $blockID }}" class="">
+<section id="{{ $blockID }}" class="cncf-footer">
     <div class="container">
       <p class="h3 p-3 mb-2 text-muted text-center">Flux is a <a href="https://cncf.io">Cloud Native Computing Foundation</a> Incubation project</p>
       <img class="mx-auto d-block img-fluid is-cncf-logo" src="{{ $logo }}" alt="Cloud Native Computing Foundation logo">


### PR DESCRIPTION
WIP for closing https://github.com/fluxcd/website/issues/109

Updates several sections to use flux branding colors. Fixes button colors and borders to follow the same color. Adds small drop shadows to the title text, links and the Get Started button in the hero section that make those items more distinct despite using similar colors. Updates link and link hover colors in all sections. Flagger green for the Flagger project box. 
Community and resources sections use $flux-gray: #2f2f2f.

These design choices need to reviewed/approved and two more items must be fixed before this PR is complete: 

> in the notes boxes, the code blocks have the same font colour as links
> the code blocks background could be greyish like we had in mkdocs, right now the contrast is huge
