### PR TITLE
Set `HUGO_ENV` for production build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,15 @@
 [build]
-publish = "public"
-command = "make production-build"
+  publish = "public"
+  command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.78.0"
+  HUGO_VERSION = "0.78.0"
+
+[context.production.environment]
+  HUGO_ENV = "production"
 
 [context.deploy-preview]
-command = "make preview-build"
+  command = "make preview-build"
 
 [context.branch-deploy]
-command = "make branch-build"
+  command = "make branch-build"


### PR DESCRIPTION
This ensures the pages are not labeled with `noindex, nofollow`.