### PR TITLE
Reenable search on legacy docs

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,9 +1,14 @@
-{{ with .Site.Params.algolia_docsearch }}
+{{ if isset .Site.Params "algolia_docsearch" }}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
 apiKey: '45f9f14d53600b0a2cafa46a26ee10f4',
 indexName: 'fluxcd',
 inputSelector: '.td-search-input',
+{{ if in .Permalink "/legacy" }}
+algoliaOptions: { 'facetFilters': ["tags:legacy"] },
+{{ else }}
+algoliaOptions: { 'facetFilters': ["tags:current"] },
+{{ end }}
 debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>


### PR DESCRIPTION
Filter on Algolia custom search tags. This can be merged some time after this is landed: https://github.com/algolia/docsearch-configs/pull/4232

Signed-off-by: Daniel Holbach <daniel@weave.works>