### PR TITLE
Front page Community section styling

### DIFF
--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -140,26 +140,58 @@ h2.section-label {
 }
 
 .section-community {
-  background-color: $flux-gray;
+  .td-box--dark {
+    background-color: $flux-gray;
+  }
+
+  .section-label {
+    padding-top: 1.5rem;
+  }
 
   section.row.td-box {
-    padding-top: 1.5rem;
+    padding: 0 0 1.5rem 0;
+
+    .td-arrow-down::before {
+      display: none;
+    }
   }
 
   .h3 {
     font-weight: 600;
   }
 
-  .join-github {
-    margin-top: 48px;
-  }
+  .community-row {
+    padding: 0;
+    margin: 1rem 0 1.5rem 0;
+    justify-content: center !important;
 
-  .join-slack, .join-ml  {
-    margin-top: 72px;
-  }
+    .community-item {
+      flex: none;
 
-  p > a {
-    font-size: 1.5rem;
+      border: 1px solid $flux-white;
+      padding: 0.5rem 1rem;
+      margin: 1rem;
+      width: 320px;
+
+      .community-item-header {
+        display: flex;
+        justify-content: center;
+
+        margin: 1rem 0;
+
+        .h3 {
+          // flex-grow: 1;
+          font-size: 1.3rem;
+          margin-left: 1rem;
+          padding-top: 9px;
+        }
+      }
+
+      a {
+        font-size: 1rem;
+        font-weight: 600;
+      }
+    }
   }
 
   h2.section-label {

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -175,7 +175,7 @@ What we achieved up until today is only possible because of our community.
 {{< blocks/section color="dark" type="community-row">}}
 
 {{< blocks/community icon="fab fa-github" title="GitHub Discussions" >}}
-<a href="https://github.com/fluxcd/flux2/discussions">Join</a> the conversation in GitHub Discussions. Everything Flux v2 related ranging from specificiations and feature planning to Show & Tell happens here.
+<a href="https://github.com/fluxcd/flux2/discussions">Join the conversation in GitHub Discussions</a>. Everything Flux v2 related ranging from specificiations and feature planning to Show & Tell happens here.
 
 {{< /blocks/community >}}
 
@@ -183,14 +183,14 @@ What we achieved up until today is only possible because of our community.
 {{< blocks/community icon="fab fa-slack" title="Slack" >}}
 If you want to talk to the Flux team and community in real-time, join us on Slack. This is a great way to get to know everyone.
 
-Get an <a href="https://slack.cncf.io/">invite</a>, or go to the <a href="https://cloud-native.slack.com/messages/flux"><code>#flux</code></a> channel.
+Get a <a href="https://slack.cncf.io/">Slack invite</a>, or go to the <a href="https://cloud-native.slack.com/messages/flux"><code>#flux</code> channel</a>.
 
 
 {{< /blocks/community >}}
 
 
 {{< blocks/community icon="fa fa-paper-plane" title="Mailing list" >}}
-<a href="https://lists.cncf.io/g/cncf-flux-dev">Join</a> our (low-traffic) mailing list to stay up to day on announcements and sporadic discussions.
+<a href="https://lists.cncf.io/g/cncf-flux-dev">Join our (low-traffic) mailing list</a> to stay up to day on announcements and sporadic discussions.
 
 {{< /blocks/community >}}
 
@@ -198,4 +198,3 @@ Get an <a href="https://slack.cncf.io/">invite</a>, or go to the <a href="https:
 </div>
 
 {{< blocks/cncf >}}
-

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -172,37 +172,27 @@ What we achieved up until today is only possible because of our community.
 {{< /blocks/lead >}}
 
 
-{{< blocks/section color="dark" type="abc_community">}}
+{{< blocks/section color="dark" type="community-row">}}
 
-{{< blocks/feature icon="fab fa-github fa-2x" title="GitHub Discussions" url="https://github.com/fluxcd/flux2/discussions" >}}
-Join the conversation in GitHub Discussions. Everything Flux v2 related ranging from specificiations and feature planning to Show & Tell happens here.
+{{< blocks/community icon="fab fa-github" title="GitHub Discussions" >}}
+<a href="https://github.com/fluxcd/flux2/discussions">Join</a> the conversation in GitHub Discussions. Everything Flux v2 related ranging from specificiations and feature planning to Show & Tell happens here.
 
-<div class="join-github">
-Join the discussion today!
-</div>
+{{< /blocks/community >}}
 
 
-{{< /blocks/feature >}}
-
-
-{{< blocks/feature icon="fab fa-slack fa-2x" title="Slack" url="https://slack.cncf.io" >}}
+{{< blocks/community icon="fab fa-slack" title="Slack" >}}
 If you want to talk to the Flux team and community in real-time, join us on Slack. This is a great way to get to know everyone.
 
-<div class="join-slack">
-Get an invite, or go to the <code>#flux</code> channel.
-</div>
-
-{{< /blocks/feature >}}
+Get an <a href="https://slack.cncf.io/">invite</a>, or go to the <a href="https://cloud-native.slack.com/messages/flux"><code>#flux</code></a> channel.
 
 
-{{< blocks/feature icon="fa fa-paper-plane fa-2x" title="Mailing list" url="https://lists.cncf.io/g/cncf-flux-dev" >}}
-Join our (low-traffic) mailing list to stay up to day on announcements and sporadic discussions.
+{{< /blocks/community >}}
 
-<div class="join-ml">
-Join the mailing list!
-</div>
 
-{{< /blocks/feature >}}
+{{< blocks/community icon="fa fa-paper-plane" title="Mailing list" >}}
+<a href="https://lists.cncf.io/g/cncf-flux-dev">Join</a> our (low-traffic) mailing list to stay up to day on announcements and sporadic discussions.
+
+{{< /blocks/community >}}
 
 {{< /blocks/section >}}
 </div>

--- a/layouts/shortcodes/blocks/community.html
+++ b/layouts/shortcodes/blocks/community.html
@@ -1,0 +1,14 @@
+{{ $icon := .Get "icon" | default "fa-lightbulb" }}
+<div class="text-center community-item">
+  <div class="community-item-header">
+    <div class="h1">
+      <i class="{{ if not (or (hasPrefix $icon "fas ") (hasPrefix $icon "fab ")) }}fas {{ end }}{{ $icon }}"></i>
+    </div>
+    <h4 class="h3">
+      {{ .Get "title" | htmlUnescape | safeHTML }}
+    </h4>
+  </div>
+  <p>
+    {{ .Inner | htmlUnescape | safeHTML }}
+  </p>
+</div>


### PR DESCRIPTION
Fixes https://github.com/fluxcd/website/issues/133

Reduced the size of the section by removing extra copy text and reducing icon size to 1x. Fixed the background to be $flux-gray (#2f2f2f). 

Switched to flexbox for individual items - the layout seems to flow well on large, medium and small screens. 