### PR TITLE
Front page item centering

### DIFF
--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -36,8 +36,6 @@ main.td-main {
   section.row {
     margin-left: 0;
     margin-right: 0;
-    // padding-left: 15px;
-    // padding-right: 15px;
   }
 }
 
@@ -105,6 +103,7 @@ h2.section-label {
   .container.rounded {
     padding-top: 2rem !important;
     padding-bottom: 2rem !important;
+    margin: 0 !important;
 
     .col > img.img-fluid {
       margin: 1rem 0 0 1rem;

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -18,6 +18,20 @@
   }
 }
 
+// center section contents and limit width for ultra-wide screens
+main.td-main {
+  section.row {
+    justify-content: center !important;
+    & > .col {
+      max-width: 1140px;
+      & > .row {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    }
+  }
+}
+
 .hero-gitops {
   section.row {
     margin-left: 0;

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -82,6 +82,25 @@ h2.section-label {
 }
 
 .section-other-flux-projects {
+  section.row.td-box > .col > .row {
+    margin: 0;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .container.rounded {
+    padding-top: 2rem !important;
+    padding-bottom: 2rem !important;
+
+    .col > img.img-fluid {
+      margin: 1rem 0 0 1rem;
+    }
+
+    .row .btn-primary {
+      margin-left: 12px;
+    }
+  }
+
   section.td-box--6 {
     background-color: $flux-dark-blue;
   }

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -18,6 +18,15 @@
   }
 }
 
+.hero-gitops {
+  section.row {
+    margin-left: 0;
+    margin-right: 0;
+    // padding-left: 15px;
+    // padding-right: 15px;
+  }
+}
+
 .features, .resources {
   .col-lg-4 {
     margin: 2rem 0rem !important;


### PR DESCRIPTION
Fixes ["Other Flux projects" section items not centered](https://github.com/fluxcd/website/issues/324)

Sets 1140px max-width for all front page sections to keep the layouts fixed on ultra-wide screens. 