### PR TITLE
Reenable foldable sidebar menu

### DIFF
--- a/assets/scss/blocks/_nav.scss
+++ b/assets/scss/blocks/_nav.scss
@@ -60,3 +60,10 @@ nav.navbar {
     font-weight: unset;
   }
 }
+
+// for now until https://github.com/google/docsy/issues/616 is fixed
+nav.foldable-nav {
+  input:checked ~ ul.foldable {
+    max-height: 1000vmax;
+  }
+}

--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ page = [ "HTML" ]
 [params.ui]
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = true
-sidebar_menu_foldable = false 	# for now until https://github.com/google/docsy/issues/616 is fixed
+sidebar_menu_foldable = true
 sidebar_menu_truncate = 1000
 
 #  Set to true to disable breadcrumb navigation.


### PR DESCRIPTION
Fixes: #371

A newer Docsy version will fix this and we can drop the override in `_nav.scss`.

Signed-off-by: Daniel Holbach <daniel@weave.works>