### PR TITLE
Fix two broken links in legacy docs

### DIFF
--- a/content/en/legacy/flux/faq.md
+++ b/content/en/legacy/flux/faq.md
@@ -24,7 +24,7 @@ Flux v1 implementation of image automation has serious performance issues scalin
 
 That's right, rate limiting undoutedly happened because of abusive clients pulling image metadata from many images (like Flux v1 did,) images that might only be stored for the purpose of retention policies, that might be relegated to cold storage if they were not being periodically retrieved.
 
-Flux v2 resolved this with [sortable image tags](/guides/sortable-image-tags/); (this is a breaking change.)
+Flux v2 resolved this with [sortable image tags](/docs/guides/sortable-image-tags/); (this is a breaking change.)
 
 Flux v1 requires one Flux daemon to be running per git repository/branch that syncs to the cluster. Flux v2 only expects cluster operators to run one source-controller instance, allowing to manage multiple repositories, or multiple clusters (or an entire fleet) with just one Flux installation.
 

--- a/content/en/legacy/flux/get-started.md
+++ b/content/en/legacy/flux/get-started.md
@@ -7,7 +7,7 @@ title: Get started
 All you need is a Kubernetes cluster and a git repo. The git repo
 contains [manifests](https://kubernetes.io/docs/concepts/configuration/overview/)
 (as YAML files) describing what should run in the cluster. Flux imposes
-[some requirements](../requirements.md) on these files.
+[some requirements](../requirements) on these files.
 
 ## Installing Flux
 


### PR DESCRIPTION
There are two broken links according to python `linkchecker`, they look like accidental migration issues related to new home for legacy docs.

Sorry for not catching these issues sooner.