### PR TITLE
flux-system service is called "webhook-receiver"

### DIFF
--- a/content/en/docs/guides/webhook-receivers.md
+++ b/content/en/docs/guides/webhook-receivers.md
@@ -75,7 +75,7 @@ spec:
         path: /
         backend:
           service:
-            name: notification-webhook
+            name: webhook-receiver
             port:
               number: 9292
 ```


### PR DESCRIPTION
I was reviewing the webhook guide part supporting Ingress, and I came across this error.

The service is not called `notification-webhook` it is called `webhook-receiver`.