### PR TITLE
De-emphasise "v2" in terminology somewhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repo houses the assets used to build the Flux project's landing page at <ht
 >
 > Project          | Docs Site                                 | Github Source
 > ---------------- | ------------------------------------------| -------------
-> Flux v2          | <https://fluxcd.io/docs>                  | <https://github.com/fluxcd/website>
+> Flux             | <https://fluxcd.io/docs>                  | <https://github.com/fluxcd/website>
 > Flagger          | <https://docs.flagger.app>                | <https://github.com/fluxcd/flagger>
-> Flux v1          | <https://fluxcd.io/legacy/flux>           | <https://github.com/fluxcd/website>
-> Helm Operator v1 | <https://fluxcd.io/legacy/helm-operator/> | <https://github.com/fluxcd/website>
+> Flux (legacy)    | <https://fluxcd.io/legacy/flux>           | <https://github.com/fluxcd/website>
+> Helm Operator    | <https://fluxcd.io/legacy/helm-operator/> | <https://github.com/fluxcd/website>
 
 ## How to modify this website
 

--- a/adopters/1-flux-v2.yaml
+++ b/adopters/1-flux-v2.yaml
@@ -1,7 +1,7 @@
 adopters:
-  project: Flux v2
+  project: Flux
   description: >
-    Check out everything about Flux v2 on our [website](https://fluxcd.io/docs/).
+    Check out everything about Flux on our [website](https://fluxcd.io/docs/).
   companies:
     - name: Weaveworks
       url: https://weave.works

--- a/adopters/3-flux-v1.yaml
+++ b/adopters/3-flux-v1.yaml
@@ -1,7 +1,7 @@
 adopters:
-  project: Flux v1
+  project: Flux (legacy)
   description: >
-    All of these organisations have been using Flux v1 and Helm Operator v1.
+    All of these organisations have been using Flux and Helm Operator.
   companies:
     - name: ABA English
       url: https://www.abaenglish.com

--- a/adopters/README.md
+++ b/adopters/README.md
@@ -6,9 +6,9 @@ So you and your organisation are using Flux? That's great. We would love to hear
 
 Each YAML file in this directory lists the organisations who adopted the specific project in production. So if you use
 
-- Flux v2 or the GitOps Toolkit controllers, you are looking for `1-flux-v2.yaml`
+- Flux or the GitOps Toolkit controllers, you are looking for `1-flux-v2.yaml`
 - Flagger, it's `2-flagger.yaml`
-- Flux v1 or Helm Operator, take a look at `3-flux-v1.yaml`
+- Flux (legacy) or Helm Operator, take a look at `3-flux-v1.yaml`
 
 You just need to add an entry for your company and upon merging it will automatically be added to our website.
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -3,7 +3,8 @@ title: Flux - the GitOps family of projects
 description: > 
   Flux is a set of continuous and progressive delivery solutions for Kubernetes, and they are open and extensible. 
   
-  The APIs of Flux are stable now. This means that now is a good time to start using the new version.
+  The APIs of Flux are stable now.
+  Now is the best time to start using Flux, or start your migration if you are a legacy user.
 ---
 
 {{% blocks/celebration emoji="🎉" url="/blog/2021/07/july-2021-update/#from-now-on-flux-apis-will-be-stable" %}}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -3,9 +3,7 @@ title: Flux - the GitOps family of projects
 description: > 
   Flux is a set of continuous and progressive delivery solutions for Kubernetes, and they are open and extensible. 
   
-  Flux v2 will be GA within the next few months! 
-  
-  This means that Flux v1 will be deprecated before the end of 2021, so now is a good time to start using v2.
+  The APIs of Flux are stable now. This means that now is a good time to start using the new version.
 ---
 
 {{% blocks/celebration emoji="🎉" url="/blog/2021/07/july-2021-update/#from-now-on-flux-apis-will-be-stable" %}}
@@ -202,7 +200,7 @@ What we achieved up until today is only possible because of our community.
 {{< blocks/section color="dark" type="community-row">}}
 
 {{< blocks/community icon="fab fa-github" title="GitHub Discussions" >}}
-<a href="https://github.com/fluxcd/flux2/discussions">Join the conversation in GitHub Discussions</a>. Everything Flux v2 related ranging from specificiations and feature planning to Show & Tell happens here.
+<a href="https://github.com/fluxcd/flux2/discussions">Join the conversation in GitHub Discussions</a>. Everything Flux related ranging from specifications and feature planning to Show & Tell happens here.
 
 {{< /blocks/community >}}
 

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -8,13 +8,13 @@ Flux is a tool for keeping Kubernetes clusters in sync with sources of
 configuration (like Git repositories), and automating updates to
 configuration when there is new code to deploy.
 
-Flux version 2 ("Flux v2") is built from the ground up to use Kubernetes'
+The new version of Flux is built from the ground up to use Kubernetes'
 API extension system, and to integrate with Prometheus and other core
 components of the Kubernetes ecosystem. In version 2, Flux supports
 multi-tenancy and support for syncing an arbitrary number of Git
 repositories, among other long-requested features.
 
-Flux v2 is constructed with the [GitOps Toolkit](components/),
+Flux is constructed with the [GitOps Toolkit](components/),
 a set of composable APIs and specialized tools for building Continuous
 Delivery on top of Kubernetes.
 
@@ -52,7 +52,7 @@ the API.
 
 ## Where do I start?
 
-{{% alert title="Get started with Flux v2!" %}}
+{{% alert title="Get started with Flux!" %}}
 Following this [guide](get-started/) will just take a couple of minutes to complete:
 After installing the `flux` CLI and running a couple of very simple commands,
 you will have a GitOps workflow setup which involves a staging and a production cluster.

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -8,7 +8,7 @@ Flux is a tool for keeping Kubernetes clusters in sync with sources of
 configuration (like Git repositories), and automating updates to
 configuration when there is new code to deploy.
 
-The new version of Flux is built from the ground up to use Kubernetes'
+Flux is built from the ground up to use Kubernetes'
 API extension system, and to integrate with Prometheus and other core
 components of the Kubernetes ecosystem. In version 2, Flux supports
 multi-tenancy and support for syncing an arbitrary number of Git

--- a/content/en/docs/components/_index.md
+++ b/content/en/docs/components/_index.md
@@ -6,7 +6,7 @@ weight: 60
 ---
 
 The GitOps Toolkit is the set of APIs and controllers that make up the
-runtime for Flux v2. The APIs comprise Kubernetes custom resources,
+runtime for Flux. The APIs comprise Kubernetes custom resources,
 which can be created and updated by a cluster user, or by other
 automation tooling.
 

--- a/content/en/docs/guides/sortable-image-tags.md
+++ b/content/en/docs/guides/sortable-image-tags.md
@@ -5,7 +5,7 @@ description: "how to construct container image tags compatible with Flux automat
 weight: 90
 ---
 
-Flux v2 does not support selecting the latest image by build time. Obtaining the build time needs
+Flux does not support selecting the latest image by build time. Obtaining the build time needs
 the container config for each image, and fetching that is subject to strict rate limiting by image
 registries (e.g., by [DockerHub][dockerhub-rates]).
 


### PR DESCRIPTION
	With moving the docs for f/flux and f/helm-operator
	under /legacy it should be even clearer now that the
	rest of the site is about the new version of flux:
	f/flux2.

	I left "v1" and "v2" in a couple of places where we
	refer to migration and do e.g. feature comparisons.

Signed-off-by: Daniel Holbach <daniel@weave.works>