### PR TITLE
Fix broken link azure

### DIFF
--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -93,7 +93,7 @@ If your Git provider is **GitHub**, **GitLab** or **Azure DevOps** please follow
 
 * [GitHub.com and GitHub Enterprise](#github-and-github-enterprise)
 * [GitLab.com and GitLab Enterprise](#gitlab-and-gitlab-enterprise)
-* [Azure DevOps](../use-cases/azure.md#flux-installation-for-azure-devops)
+* [Azure DevOps](../use-cases/azure#flux-installation-for-azure-devops)
 
 ### Generic Git Server
 

--- a/docker-support/Dockerfile
+++ b/docker-support/Dockerfile
@@ -15,7 +15,7 @@ RUN apk update && \
 	python3 \
 	py3-pip
 
-RUN python3 -m pip install pyyaml
+RUN python3 -m pip install pyyaml pathlib
 RUN ln -s `which python3` /usr/bin/python
 
 # VOLUME /site	# provided by upstream


### PR DESCRIPTION
Resolves #406 

Also fixes the `make docker-preview`, which was failing with this cryptic message because of a missing `pathlib` import:

```
make: hack/gen-content.py: No such file or directory
```

(Someone must run `make docker-push` with push access to fluxcd/website in order to publish the fix, it might be time to implement some CI that verifies we haven't changed something in a way that breaks the docker-preview functionality, and to permit updating of the `website:hugo-support` image more simply, by anyone and with a pull request.)