### PR TITLE
Add time unit to timeout docs for hrs

### DIFF
--- a/content/en/legacy/helm-operator/helmrelease-guide/release-configuration.md
+++ b/content/en/legacy/helm-operator/helmrelease-guide/release-configuration.md
@@ -126,11 +126,11 @@ spec:
 ## Configuring the timeout
 
 To configure how many seconds Helm should wait for any individual Kubernetes operations
-you can set `.timeout`, the default is `300`:
+you can set `.timeout`, the default is `300s`:
 
 ```yaml
 spec:
-  timeout: 300
+  timeout: 300s
 ```
 
 {{% alert color="warning" title="Warning" %}}


### PR DESCRIPTION
Without a time unit this will throw: 

```
E0723 03:35:14.522782       6 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.4/tools/cache/reflector.go:167: Failed to watch *v2beta1.HelmRelease: failed to list *v2beta1.HelmRelease: v2beta1.HelmReleaseList.Items: []v2beta1.HelmRelease: v2beta1.HelmRelease.Spec: v2beta1.HelmReleaseSpec.Values: Timeout: unmarshalerDecoder: time: missing unit in duration "600", error found in #10 byte of ...|out":"600","values":|..., bigger context ...|m","releaseName":"keycloak","timeout":"600","values":{"clusterDomain":"cluster.local","extraE|...
```