### PR TITLE
fix sortable image tag pattern for github run number example

### DIFF
--- a/content/en/docs/guides/sortable-image-tags.md
+++ b/content/en/docs/guides/sortable-image-tags.md
@@ -162,7 +162,7 @@ spec:
   imageRepositoryRef:
     name: image-repo
   filterTags:
-    ## use "pattern: '(?P<ts>.*)-.+'" if you copied the workflow example using github.run_number
+    ## use "pattern: '[a-f0-9]+-(?P<ts>[0-9]+)'" if you copied the workflow example using github.run_number
     pattern: '^main-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:


### PR DESCRIPTION
Signed-off-by: Frederik Baetens <baetens.fr@gmail.com>

The order of the sha & run number were swapped between the github actions workflow example and the pattern.