### PR TITLE
update hugo version everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ FONT_AWESOME_SEMVER_FOLDER := Font-Awesome-$(FONT_AWESOME_SEMVER)
 FONT_AWESOME_TARGET        := themes/$(DOCSY_COMMIT_FOLDER)/assets/vendor/$(FONT_AWESOME_SEMVER_FOLDER)
 
 DEV_IMAGE_REGISTRY_NAME    ?= fluxcd
-HUGO_VERSION               ?= 0.84.3
+HUGO_VERSION               ?= 0.86.0
 HUGO_IMAGE_BASE_NAME       := website:hugo-$(HUGO_VERSION)-extended
 SUPPORT_IMAGE_BASE_NAME    := website:hugo-support
 HUGO_IMAGE_NAME            ?= $(DEV_IMAGE_REGISTRY_NAME)/$(HUGO_IMAGE_BASE_NAME)

--- a/docker-support/Dockerfile
+++ b/docker-support/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluxcd/website:hugo-0.78.2-extended
+FROM fluxcd/website:hugo-0.86.0-extended
 
 RUN apk update && \
     apk add --no-cache \

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "make production-build"
 
 [build.environment]
-  HUGO_VERSION = "0.84.3"
+  HUGO_VERSION = "0.86.0"
 
 [context.production.environment]
   HUGO_ENV = "production"


### PR DESCRIPTION
Unfortunately we specify hugo versions in too many places, with this PR I'll bring all of them up to the same version:

```cli
❯ git grep 0.86.0
Makefile:HUGO_VERSION               ?= 0.86.0
docker-support/Dockerfile:FROM fluxcd/website:hugo-0.86.0-extended
netlify.toml:  HUGO_VERSION = "0.86.0"
package-lock.json:      "version": "0.86.0",
package-lock.json:      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.86.0.tgz",
package.json:    "hugo-extended": "^0.86.0",
website on  update-hugo [$] via  v12.22.3 via 🐍 v3.8.10
❯ 
```
