### PR TITLE
Fixed missing name on "flux create helmrelease"

### DIFF
--- a/content/en/docs/use-cases/helm.md
+++ b/content/en/docs/use-cases/helm.md
@@ -49,7 +49,7 @@ Flux client:
 
 ```sh
 flux create source helm traefik --url https://helm.traefik.io/traefik
-flux create helmrelease --chart my-traefik \
+flux create helmrelease traefik --chart my-traefik \
   --source HelmRepository/traefik \
   --chart-version 9.18.2 \
   --namespace traefik


### PR DESCRIPTION
Without it the `flux create` would emit error:
```
✗ HelmRelease name is required
```