### PR TITLE
added the standard controller name for kubeseal

### DIFF
--- a/content/en/docs/guides/sealed-secrets.md
+++ b/content/en/docs/guides/sealed-secrets.md
@@ -53,7 +53,7 @@ Create a Helm release that installs the latest version of sealed-secrets control
 ```sh
 flux create helmrelease sealed-secrets \
 --interval=1h \
---release-name=sealed-secrets \
+--release-name=sealed-secrets-controller \
 --target-namespace=flux-system \
 --source=HelmRepository/sealed-secrets \
 --chart=sealed-secrets \
@@ -71,7 +71,7 @@ You can retrieve the public key with:
 
 ```sh
 kubeseal --fetch-cert \
---controller-name=sealed-secrets \
+--controller-name=sealed-secrets-controller \
 --controller-namespace=flux-system \
 > pub-sealed-secrets.pem
 ``` 
@@ -149,7 +149,7 @@ spec:
         name: sealed-secrets
       version: ">=1.15.0-0"
   interval: 1h0m0s
-  releaseName: sealed-secrets
+  releaseName: sealed-secrets-controller
   targetNamespace: flux-system
   install:
     crds: Create


### PR DESCRIPTION
As described here: https://github.com/bitnami-labs/sealed-secrets/issues/317#issuecomment-718608815 the standard controller name for kubeseal is sealed-secrets-controller and if you only use sealed-secrets you need to define another enrironment variable called: SEALED_SECRETS_CONTROLLER_NAME.

So as an alternative to my pull request you can also add the text for using this variable.