### PR TITLE
Read Flux meeting ical

### DIFF
--- a/.github/workflows/lychee-cron.yaml
+++ b/.github/workflows/lychee-cron.yaml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/setup-python@v2.2.2
         with:
           python-version: 3.8
-      - name: "Install prerequisites"
-        run: |
-          pip3 install -r requirements.txt
+      - uses: BSFishy/pip-action@v1
+        with:
+          requirements: requirements.txt
       - run: |
           make gen-content
       - name: Link Checker

--- a/.github/workflows/lychee-pr.yaml
+++ b/.github/workflows/lychee-pr.yaml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/setup-python@v2.2.2
         with:
           python-version: 3.8
-      - name: "Install prerequisites"
-        run: |
-          pip3 install -r requirements.txt
+      - uses: BSFishy/pip-action@v1
+        with:
+          requirements: requirements.txt
       - name: get changed files
         id: getfile
         run: |

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ $(FONT_AWESOME_TARGET): ## Downloads the Docsy Font Awesome dependency.
 gen-content: ## Generates content from external sources.
 	hack/adopters.py
 	hack/gen-content.py
+	hack/import-calendar.py
 	hack/import-flux2-assets.sh
 
 serve: gen-content theme ## Spawns a development server.

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -239,6 +239,11 @@ h2.section-label {
 }
 
 .section-community {
+
+  @include gray-background-a;
+  background-color: $flux-gray;
+
+
   .td-box--dark {
     background-color: $flux-gray;
   }
@@ -301,7 +306,64 @@ h2.section-label {
     margin: 1rem 0 2rem 0;
   }
 
-  @include gray-background-a;
+  .calendar {
+    // margin: 0 -15px;
+    padding: 0 1rem;
+    max-width: 600px;
+    margin: 0 auto;
+
+    h3 {
+      font-weight: 600;
+      text-align: center;
+    }
+    p.caption {
+      text-align: center;
+      margin: 1rem 0 2rem 0;
+    }
+
+    p.details {
+      padding-top: 2rem;
+      font-weight: 500;
+    }
+
+    table {
+      margin: 0 auto;
+
+      tr {
+        border-bottom: 1px solid rgba($flux-white, 0.25);
+
+        &:last-child {
+          border: none;
+        }
+
+        td {
+          vertical-align: top;
+          padding: 6px 0;
+        }
+        td.date {
+          width: 6rem;
+          text-align: left;
+          font-weight: 500;
+        }
+
+        td.time {
+          width: 3rem;
+          padding-right: 1rem;
+          font-weight: 200;
+        }
+
+        td.label {
+          font-weight: 500;
+        }
+
+      }
+    }
+
+
+  }
+
+
+
 }
 
 .container.contributors {

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -306,7 +306,7 @@ h2.section-label {
     margin: 1rem 0 2rem 0;
   }
 
-  .calendar {
+  .team-calendar {
     // margin: 0 -15px;
     padding: 0 1rem;
     max-width: 600px;

--- a/content/en/.gitignore
+++ b/content/en/.gitignore
@@ -2,6 +2,7 @@
 adopters.md
 adopters_carousel_include.html
 adopters_bg_include.html
+calendar_include.html
 
 # Imported
 community.md

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -163,7 +163,7 @@ Get a <a href="https://slack.cncf.io/">Slack invite</a>, or go to the <a href="h
 {{< /blocks/community >}}
 
 
-
+{{< blocks/calendar >}}
 
 
 {{< /blocks/section >}}

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -166,8 +166,8 @@ Get a <a href="https://slack.cncf.io/">Slack invite</a>, or go to the <a href="h
 
 {{< blocks/section color="dark" type="calendar-row">}}
 {{< blocks/calendar >}}
+{{< /blocks/section >}}
 
-{{< /blocks/section>}}
 </div>
 
 <!-- RESOURCES HERE -->

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -162,11 +162,12 @@ Get a <a href="https://slack.cncf.io/">Slack invite</a>, or go to the <a href="h
 
 {{< /blocks/community >}}
 
+{{< /blocks/section >}}
 
+{{< blocks/section color="dark" type="calendar-row">}}
 {{< blocks/calendar >}}
 
-
-{{< /blocks/section >}}
+{{< /blocks/section>}}
 </div>
 
 <!-- RESOURCES HERE -->

--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -21,6 +21,7 @@ if os.path.exists('/opt/hostedtoolcache/Python'):
 
 
 from icalendar import Calendar
+import pytz
 import recurring_ical_events
 import urllib3
 
@@ -46,7 +47,9 @@ def read_calendar(cal):
     next_month = today+timedelta(days=30)
     for event in recurring_ical_events.of(gcal).between(today, next_month):
         events += [
-            (event['dtstart'].dt, event['summary'], event['description'])
+            (event['dtstart'].dt.astimezone(pytz.utc),
+             event['summary'],
+             event['description'])
         ]
     events.sort()
     return events
@@ -66,11 +69,9 @@ def write_events_html(events):
         <tr>
             <td>{}<td>
             <td>{}<td>
-            <td>{}<td>
         </tr>
 """.format(
     event[0].strftime('%F %H:%M'),
-    event[0].tzinfo,
     event[1])
 
     html += """

--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python
+
+from datetime import (date, timedelta)
+import os
+import sys
+
+# Workaround to make this work in Netlify...
+LOCAL_PY_PATH = '/opt/buildhome/python3.7/lib/python3.7/site-packages/'
+if LOCAL_PY_PATH not in sys.path:
+    sys.path.append(LOCAL_PY_PATH)
+
+from icalendar import Calendar
+import recurring_ical_events
+import urllib3
+
+CAL_URL = 'https://lists.cncf.io/g/cncf-flux-dev/ics/4130481/1290943905/feed.ics'
+
+TOP_LEVEL_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), '..'))
+CONTENT_DIR = os.path.join(TOP_LEVEL_DIR, 'content/en')
+CALENDAR_INCLUDE_HTML = os.path.join(CONTENT_DIR, 'calendar_include.html')
+
+def download_calendar():
+    http = urllib3.PoolManager()
+    r = http.request('GET', CAL_URL)
+    if r.status != 200:
+        print('Error retrieving calendar.', sys.stderr)
+        return None
+    return r.data
+
+def read_calendar(cal):
+    events = []
+    gcal = Calendar.from_ical(cal)
+    today = date.today()
+    next_month = today+timedelta(days=30)
+    for event in recurring_ical_events.of(gcal).between(today, next_month):
+        events += [
+            (event['dtstart'].dt, event['summary'], event['description'])
+        ]
+    events.sort()
+    return events
+
+def write_events_html(events):
+    if os.path.exists(CALENDAR_INCLUDE_HTML):
+        os.remove(CALENDAR_INCLUDE_HTML)
+
+    if not events:
+        return
+
+    html = """
+    <table>"""
+
+    for event in events:
+        html += """
+        <tr>
+            <td>{}<td>
+            <td>{}<td>
+            <td>{}<td>
+        </tr>
+""".format(
+    event[0].strftime('%F %H:%M'),
+    event[0].tzinfo,
+    event[1])
+
+    html += """
+    </table>"""
+
+    f = open(CALENDAR_INCLUDE_HTML, 'w')
+    f.write(html)
+    f.close()
+
+def main():
+    cal = download_calendar()
+    if not cal:
+        sys.exit(1)
+    events = read_calendar(cal)
+    write_events_html(events)
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Aborted.', sys.stderr)
+        sys.exit(1)

--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -67,11 +67,13 @@ def write_events_html(events):
     for event in events:
         html += """
         <tr>
-            <td>{}<td>
-            <td>{}<td>
+            <td class="date">{}</td>
+            <td class="time">{}</td>
+            <td class="label">{}</td>
         </tr>
 """.format(
-    event[0].strftime('%F %H:%M'),
+    event[0].strftime('%F'),
+    event[0].strftime('%H:%M'),
     event[1])
 
     html += """

--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 from datetime import (date, timedelta)
+import glob
 import os
 import sys
 
@@ -8,6 +9,16 @@ import sys
 LOCAL_PY_PATH = '/opt/buildhome/python3.7/lib/python3.7/site-packages/'
 if LOCAL_PY_PATH not in sys.path:
     sys.path.append(LOCAL_PY_PATH)
+
+# I hate doing this... but we've got to make this work on Github Actions...
+if os.path.exists('/opt/hostedtoolcache/Python'):
+    VERSION_INFO = sys.version_info
+    LOCATION = '/opt/hostedtoolcache/Python/{}.{}.*/*/lib/python*/site-packages'.format(
+        VERSION_INFO.major, VERSION_INFO.minor)
+    LOCAL_PY_PATHS = glob.glob(LOCATION)
+    if LOCAL_PY_PATHS and LOCAL_PY_PATHS[0] not in sys.path:
+        sys.path.append(LOCAL_PY_PATHS[0])
+
 
 from icalendar import Calendar
 import recurring_ical_events

--- a/layouts/shortcodes/blocks/calendar.html
+++ b/layouts/shortcodes/blocks/calendar.html
@@ -1,0 +1,7 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ if (fileExists "/content/en/calendar_include.html") -}}
+<div class="container calendar">
+    <h3>Our team calendar</h3>
+    {{ readFile "/content/en/calendar_include.html" | safeHTML }}
+</div>
+{{ end }}

--- a/layouts/shortcodes/blocks/calendar.html
+++ b/layouts/shortcodes/blocks/calendar.html
@@ -2,7 +2,7 @@
 <div class="container calendar">
     <h3>Our team calendar</h3>
     {{ if (fileExists "/content/en/calendar_include.html") -}}
-    <p>The upcoming meetings, talks and community events in the next month are listed below.</p>
+    <p>The upcoming meetings, talks and community events in the next month are listed below. (All times are UTC.)</p>
     {{ readFile "/content/en/calendar_include.html" | safeHTML }}
     {{ end }}
     <p>See <a href="https://lists.cncf.io/g/cncf-flux-dev/calendar">this page</a>

--- a/layouts/shortcodes/blocks/calendar.html
+++ b/layouts/shortcodes/blocks/calendar.html
@@ -1,7 +1,10 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-{{ if (fileExists "/content/en/calendar_include.html") -}}
 <div class="container calendar">
     <h3>Our team calendar</h3>
+    {{ if (fileExists "/content/en/calendar_include.html") -}}
+    <p>The upcoming meetings, talks and community events in the next month are listed below.</p>
     {{ readFile "/content/en/calendar_include.html" | safeHTML }}
+    {{ end }}
+    <p>See <a href="https://lists.cncf.io/g/cncf-flux-dev/calendar">this page</a>
+        for more detail and subscription options.</p>
 </div>
-{{ end }}

--- a/layouts/shortcodes/blocks/calendar.html
+++ b/layouts/shortcodes/blocks/calendar.html
@@ -1,10 +1,10 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-<div class="container calendar">
-    <h3>Our team calendar</h3>
+<div class="calendar">
+    <h3>Our Team Calendar</h3>
     {{ if (fileExists "/content/en/calendar_include.html") -}}
-    <p>The upcoming meetings, talks and community events in the next month are listed below. (All times are UTC.)</p>
+    <p class="caption">The upcoming meetings, talks and community events in the next month are listed below. (All times are UTC.)</p>
     {{ readFile "/content/en/calendar_include.html" | safeHTML }}
     {{ end }}
-    <p>See <a href="https://lists.cncf.io/g/cncf-flux-dev/calendar">this page</a>
+    <p class="details">See <a href="https://lists.cncf.io/g/cncf-flux-dev/calendar">this page</a>
         for more detail and subscription options.</p>
 </div>

--- a/layouts/shortcodes/blocks/calendar.html
+++ b/layouts/shortcodes/blocks/calendar.html
@@ -1,6 +1,6 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-<div class="calendar">
-    <h3>Our Team Calendar</h3>
+<div class="team-calendar">
+    <h3 id="calendar">Our Team Calendar</h3>
     {{ if (fileExists "/content/en/calendar_include.html") -}}
     <p class="caption">The upcoming meetings, talks and community events in the next month are listed below. (All times are UTC.)</p>
     {{ readFile "/content/en/calendar_include.html" | safeHTML }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+icalendar
 pathlib
 pygithub
+python-dateutil>=2.8.1
 pyYaml
+recurring-ical-events
+urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pathlib
 pygithub
 python-dateutil>=2.8.1
 pyYaml
+pytz
 recurring-ical-events
 urllib3


### PR DESCRIPTION
Read the cncf-flux-dev calendar (ical) and show the events in the upcoming month.

Fixes: #449

Things that still need doing:

- [x] link to the calendar so folks know how to find out more (Daniel)
- [x] do timezone arithmetic so everything is in one TZ
- [x] make this look pretty (@juozasg)
- [x] decide as a group that we want to also keep track of talks, etc in our cncf-flux-dev calendar


---

~~- [ ] make sure everyone involved has access to the calendar~~ (moved to https://github.com/fluxcd/community/issues/113)
~~- [ ] hook up calendar include generation with daily cronjob~~ (should be handled by https://github.com/fluxcd/website/blob/main/.github/workflows/netlify.yml)
~~- [ ] figure out if we can link to the events in question... do we get the data in the ICS somewhere (Daniel)~~ - moved to #461
~~- [ ] make links clickable in the event description~~ - moved to #461
~~- [ ] have a mouse-over with event data (@juozasg + Daniel)~~ - moved to #461
~~- [ ] maybe convert to browser TZ(?)~~ - moved to #461