### PR TITLE
Update resources video url

### DIFF
--- a/content/en/resources.md
+++ b/content/en/resources.md
@@ -90,7 +90,7 @@ title="GitOpsCon at KubeCon EU!" %}}
 {{% /blocks/resource %}}
 
 {{% blocks/resource
-url="https://www.conf42.com/Cloud_Native_2021_Leonardo_Murillo_gitops_multicloud_crossplane_flux2"
+youtube="AyRhi92v9O0?t=40"
 title="Doing GitOps for multicloud resource management using Crossplane and Flux2 (at Conf42: Cloud Native 2021)" %}}
 {{% /blocks/resource %}}
 

--- a/content/en/resources.md
+++ b/content/en/resources.md
@@ -91,6 +91,7 @@ title="GitOpsCon at KubeCon EU!" %}}
 
 {{% blocks/resource
 youtube="AyRhi92v9O0?t=40"
+thumbnail="AyRhi92v9O0"
 title="Doing GitOps for multicloud resource management using Crossplane and Flux2 (at Conf42: Cloud Native 2021)" %}}
 {{% /blocks/resource %}}
 


### PR DESCRIPTION
Not sure if I did this correctly or not, but please let me know @dholbach :)
Updated Leo's talk from Conf42 with YouTube video link (instead of conf reg page link): https://youtu.be/AyRhi92v9O0?t=40

Signed-off-by: Stacey Potter <50154848+staceypotter@users.noreply.github.com>