### PR TITLE
Update doc about CoreDNS addon patching

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -175,8 +175,9 @@ the controller and validates the output using `kubeval`.
 ### How to patch CoreDNS and other pre-installed addons?
 
 To patch a pre-installed addon like CoreDNS with customized content.
-Simple add a shell manifest with only the changed values and `kustomize.toolkit.fluxcd.io/prune: disabled` annotation into your git repository.
-In addition, fields such as selector and template should exist and contain an empty map. This will not override the existing values.
+Simply add a shell manifest with only the changed values and `kustomize.toolkit.fluxcd.io/prune: disabled` annotation into your git repository. The `kustomize.toolkit.fluxcd.io/v1beta1` processing this manifest should have `validation: server`.
+
+In addition you will notice that fields such as `selector` and `template` exist and contain an empty map. This will not override the existing values but is required for the patching to work.
 
 Example CoreDNS with custom replicas:
 ```yaml

--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -176,8 +176,9 @@ the controller and validates the output using `kubeval`.
 
 To patch a pre-installed addon like CoreDNS with customized content.
 Simple add a shell manifest with only the changed values and `kustomize.toolkit.fluxcd.io/prune: disabled` annotation into your git repository.
+In addition, fields such as selector and template should exist and contain an empty map. This will not override the existing values.
 
-Example CoreDNS with podAntiAffinity
+Example CoreDNS with custom replicas:
 ```yaml
 ---
 apiVersion: apps/v1
@@ -190,26 +191,15 @@ metadata:
   name: coredns
   namespace: kube-system
 spec:
-  selector:
-    matchLabels:
-      k8s-app: kube-dns
+  replicas: 3
+  selector: {}
   template:
-    metadata:
-      labels:
-        k8s-app: kube-dns
+    metadata: {}
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  k8s-app: kube-dns
-              topologyKey: kubernetes.io/hostname
-            weight: 100
-      containers:
-      - name: coredns
+      containers: []
 ```
+
+Note that only non-managed fields should be modified else there will be a conflict with the `manager` of the fields (e.g. `eks`). For example, while you will be able to modify affinity/antiaffinity fields, the `manager` (e.g. `eks`) will revert those changes and that might not be immediately visible to you (with EKS that would be an interval of once every 30 minutes). The deployment will go into a rolling upgrade and flux will revert it back to the patched version.
 
 ## Helm questions
 


### PR DESCRIPTION
1. The example in the FAQ didn't work because the CoreDNS deployment is managed by EKS. EKS manages fields for affinity rules (see https://docs.aws.amazon.com/eks/latest/userguide/add-ons-configuration.html). This causes EKS to update the deployment once every 30 minutes (rolling upgrade) and flux will immediately revert that back, causing rolling upgrades to keep on happening on the cluster.

2. Another reason the example in the FAQ didn't work: this is an existing deployment deployed outside of Flux and we have to manage it differently as we must add the `selector` and `template` fields.

3. Changed the example to modify the `replicas` is this is a non-managed field and can be safely updated.