### PR TITLE
Front page calendar details dropdowns

### DIFF
--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -1,0 +1,11 @@
+var $ = window.$;
+
+$('.calendar-list li').click(function() {
+  var card = $(this).children('.calendar-card');
+  card.slideDown(500);
+});
+
+$('.calendar-list li').mouseleave(function() {
+  var card = $(this).children('.calendar-card');
+  card.slideUp(500);
+});

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -2,10 +2,7 @@ var $ = window.$;
 
 $('.calendar-list li').click(function() {
   var card = $(this).children('.calendar-card');
-  card.slideDown(500);
-});
+  $('.calendar-card').not(card).slideUp(500);
 
-$('.calendar-list li').mouseleave(function() {
-  var card = $(this).children('.calendar-card');
-  card.slideUp(500);
+  card.slideDown(500);
 });

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -305,65 +305,6 @@ h2.section-label {
   h2.section-label {
     margin: 1rem 0 2rem 0;
   }
-
-  .team-calendar {
-    // margin: 0 -15px;
-    padding: 0 1rem;
-    max-width: 600px;
-    margin: 0 auto;
-
-    h3 {
-      font-weight: 600;
-      text-align: center;
-    }
-    p.caption {
-      text-align: center;
-      margin: 1rem 0 2rem 0;
-    }
-
-    p.details {
-      padding-top: 2rem;
-      font-weight: 500;
-    }
-
-    table {
-      margin: 0 auto;
-
-      tr {
-        border-bottom: 1px solid rgba($flux-white, 0.25);
-
-        &:last-child {
-          border: none;
-        }
-
-        td {
-          vertical-align: top;
-          padding: 6px 0;
-        }
-        td.date {
-          width: 6rem;
-          text-align: left;
-          font-weight: 500;
-        }
-
-        td.time {
-          width: 3rem;
-          padding-right: 1rem;
-          font-weight: 200;
-        }
-
-        td.label {
-          font-weight: 500;
-        }
-
-      }
-    }
-
-
-  }
-
-
-
 }
 
 .container.contributors {

--- a/assets/scss/blocks/_blocks.scss
+++ b/assets/scss/blocks/_blocks.scss
@@ -1,3 +1,4 @@
 @import "nav";
 @import "cncf";
 @import "hero";
+@import "calendar"

--- a/assets/scss/blocks/_calendar.scss
+++ b/assets/scss/blocks/_calendar.scss
@@ -88,12 +88,13 @@
       max-width: 600px;
 
       padding: 0 1rem 1rem 1rem;
-      word-break: break-all;
+      // word-break: break-all;
       border-bottom: none;
       font-size: 0.9rem;
 
       ul.details-list {
         margin: 0;
+        margin-top: 0.5rem;
         padding: 0;
         list-style-type: none;
         li {

--- a/assets/scss/blocks/_calendar.scss
+++ b/assets/scss/blocks/_calendar.scss
@@ -1,0 +1,127 @@
+$card-bg: rgba(white, 0.75);
+
+
+.team-calendar {
+  // margin: 0 -15px;
+  padding: 0 1rem;
+  max-width: 600px;
+  margin: 0 auto;
+
+  h3 {
+    font-weight: 600;
+    text-align: center;
+  }
+  p.caption {
+    text-align: center;
+    margin: 1rem 0 2rem 0;
+  }
+
+  p.details {
+    padding-top: 2rem;
+    font-weight: 500;
+  }
+
+  table {
+    margin: 0 auto;
+
+    tr {
+      border-bottom: 1px solid rgba($flux-white, 0.25);
+
+      &:last-child {
+        border: none;
+      }
+
+      td {
+        vertical-align: bottom;
+        padding: 6px 0;
+      }
+      td.date {
+        width: 7rem;
+        text-align: left;
+        font-weight: 500;
+        padding-left: 1rem;
+      }
+
+      td.time {
+        width: 3rem;
+        padding-right: 1rem;
+        font-weight: 200;
+      }
+
+      td.label {
+        font-weight: 500;
+      }
+
+    }
+    tr.calendar-card td {
+      display: none;
+      max-width: 600px;
+    }
+
+    tr:nth-child(5) {
+      border-bottom: none;
+      td {
+        // background: $card-bg;
+        // color: $flux-black;
+        font-weight: 600;
+        // border-bottom: 1px solid rgba($flux-black, 0.25);
+        border-bottom: none;
+
+        text-decoration: underline;
+
+      }
+
+      td.label {
+        // font-size: 1.2rem;
+      }
+
+    }
+
+    tr.calendar-card {
+      td {
+        // margin-top: 1.5rem;
+
+        display: table-cell;
+        // background: $card-bg;
+        // color: $flux-b0 lack;
+
+        padding: 0 1rem 1rem 1rem;
+        word-break: break-all;
+        border-bottom: none;
+        font-size: 0.9rem;
+        
+        dt:first-child {
+          // margin-top: 4px;
+          // margin-bottom: 4px;
+        }
+
+        dt:nth-of-type(2) {
+          margin-bottom: 8px;
+        }
+
+        dt {
+          // margin-top: 0.5rem;
+          color: rgba($flux-white, 0.75);
+          display: inline-block;
+          width: 8.5rem;
+          text-align: right;
+          // margin-bottom: 6px;
+        }
+
+        dd {
+          padding-left: 1rem;
+          color: rgba($flux-white, 1);
+          display: inline;
+          clear: both;
+        }
+
+        dd::after { content: '\A'; white-space:pre; height: 0px; font-size: 1px;}
+
+        a {
+            // color: $flux-darkest-blue !important; 
+        }
+      }
+    }
+  }
+}
+

--- a/assets/scss/blocks/_calendar.scss
+++ b/assets/scss/blocks/_calendar.scss
@@ -1,8 +1,4 @@
-$card-bg: rgba(white, 0.75);
-
-
 .team-calendar {
-  // margin: 0 -15px;
   padding: 0 1rem;
   max-width: 600px;
   margin: 0 auto;
@@ -21,105 +17,108 @@ $card-bg: rgba(white, 0.75);
     font-weight: 500;
   }
 
-  table {
+  ul.calendar-list {
     margin: 0 auto;
+    list-style-type: none;
 
-    tr {
+    & > li {
       border-bottom: 1px solid rgba($flux-white, 0.25);
+     
+      .label {
+        text-decoration: underline 0.15em rgba($flux-white, 0);
+        text-underline-offset: 0.2em;
+        transition: text-decoration-color 300ms;
+      }
+
+      &:hover {
+        .label {
+          text-decoration-color: rgba($flux-white, 0.75);
+          text-underline-offset: 0.2em;
+          cursor: pointer;
+        }
+      }
+
+      @media (hover: none) {
+        border-bottom: none;
+        .label {
+          text-underline-offset: 0.2em;
+          text-decoration: underline 0.15em rgba($flux-white, 0.25);
+        }
+      }
 
       &:last-child {
         border: none;
       }
 
-      td {
-        vertical-align: bottom;
-        padding: 6px 0;
-      }
-      td.date {
-        width: 7rem;
+      .date {
+        display: inline-block;
+        width: 6rem;
         text-align: left;
         font-weight: 500;
-        padding-left: 1rem;
+        color:rgba($flux-white, 0.75);
+
+        padding: 6px 0;
+
+        vertical-align: bottom;
       }
 
-      td.time {
+      .time {
+        display: inline-block;
         width: 3rem;
-        padding-right: 1rem;
-        font-weight: 200;
+
+        padding: 6px 0;
+        padding-right: 2rem;
+        font-weight: 300;
+        color:rgba($flux-white, 0.75);
+
+        vertical-align: bottom;
       }
 
-      td.label {
+      .label {
+        display: inline-block;
+
+        padding: 6px 0;
         font-weight: 500;
+        vertical-align: bottom;
       }
-
     }
-    tr.calendar-card td {
+
+    .calendar-card {
       display: none;
       max-width: 600px;
-    }
 
-    tr:nth-child(5) {
+      padding: 0 1rem 1rem 1rem;
+      word-break: break-all;
       border-bottom: none;
-      td {
-        // background: $card-bg;
-        // color: $flux-black;
-        font-weight: 600;
-        // border-bottom: 1px solid rgba($flux-black, 0.25);
-        border-bottom: none;
+      font-size: 0.9rem;
 
-        text-decoration: underline;
-
+      ul.details-list {
+        margin: 0;
+        padding: 0;
+        list-style-type: none;
+        li {
+          margin-top: 3px;
+        }
+      }
+      
+      dt {
+        color: rgba($flux-white, 0.75);
+        display: inline-block;
+        width: 7.5rem;
+        text-align: right;
       }
 
-      td.label {
-        // font-size: 1.2rem;
+      dd {
+        margin: 0;
+        padding-left: 14px;
+        color: rgba($flux-white, 1);
+        display: inline-block;
+        clear: both;
       }
 
-    }
-
-    tr.calendar-card {
-      td {
-        // margin-top: 1.5rem;
-
-        display: table-cell;
-        // background: $card-bg;
-        // color: $flux-b0 lack;
-
-        padding: 0 1rem 1rem 1rem;
-        word-break: break-all;
-        border-bottom: none;
-        font-size: 0.9rem;
-        
-        dt:first-child {
-          // margin-top: 4px;
-          // margin-bottom: 4px;
-        }
-
-        dt:nth-of-type(2) {
-          margin-bottom: 8px;
-        }
-
-        dt {
-          // margin-top: 0.5rem;
-          color: rgba($flux-white, 0.75);
-          display: inline-block;
-          width: 8.5rem;
-          text-align: right;
-          // margin-bottom: 6px;
-        }
-
-        dd {
-          padding-left: 1rem;
-          color: rgba($flux-white, 1);
-          display: inline;
-          clear: both;
-        }
-
-        dd::after { content: '\A'; white-space:pre; height: 0px; font-size: 1px;}
-
-        a {
-            // color: $flux-darkest-blue !important; 
-        }
+      .description {
+        margin-top: 12px;
+        display: block;
       }
     }
   }

--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -66,10 +66,21 @@ def write_events_html(events):
 
     for event in events:
         html += """
-        <tr>
+        <tr class="calendar-row">
             <td class="date">{}</td>
             <td class="time">{}</td>
             <td class="label">{}</td>
+        </tr>
+        <tr class="calendar-card">
+            <td colspan=3>
+                <dt>Where</dt>
+                <dd><a href="#">https://zoom.com/abcd</a></dd>
+
+                <dt>Organizer</dt>
+                <dd>Daniel Holback <a href="#">daniel@weave.works</a></dd>
+
+                <span class="description">Meetings minute agenda and videos <a href="#">https://docs.google.com/spreadsheets/d/1WcRgC7tXNpCK4AGm7fg37oesyVKr3THdJXQBlVq0rG8/edit#gid=220199767</a></span>
+            </td>
         </tr>
 """.format(
     event[0].strftime('%F'),

--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -62,33 +62,40 @@ def write_events_html(events):
         return
 
     html = """
-    <table>"""
+    <ul class="calendar-list">"""
 
     for event in events:
         html += """
-        <tr class="calendar-row">
-            <td class="date">{}</td>
-            <td class="time">{}</td>
-            <td class="label">{}</td>
-        </tr>
-        <tr class="calendar-card">
-            <td colspan=3>
-                <dt>Where</dt>
-                <dd><a href="#">https://zoom.com/abcd</a></dd>
-
-                <dt>Organizer</dt>
-                <dd>Daniel Holback <a href="#">daniel@weave.works</a></dd>
+        <li>
+            <div class="calendar-row">
+                <div class="date">{}</div>
+                <div class="time">{}</div>
+                <div class="label">{}</div>
+            </div>
+            <div class="calendar-card">
+                <ul class="details-list">
+                    <li>
+                        <dt>Where</dt>
+                        <dd><a href="#">https://zoom.com/abcd</a></dd>
+                    </li>
+                    
+                    <li>
+                        <dt>Organizer</dt>
+                        <dd>Daniel Holback <a href="#">daniel@weave.works</a></dd>
+                    </li>
+                </ul>
 
                 <span class="description">Meetings minute agenda and videos <a href="#">https://docs.google.com/spreadsheets/d/1WcRgC7tXNpCK4AGm7fg37oesyVKr3THdJXQBlVq0rG8/edit#gid=220199767</a></span>
-            </td>
-        </tr>
+            </div>
+        </li>
+
 """.format(
     event[0].strftime('%F'),
     event[0].strftime('%H:%M'),
     event[1])
 
     html += """
-    </table>"""
+    </ul>"""
 
     f = open(CALENDAR_INCLUDE_HTML, 'w')
     f.write(html)

--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -70,7 +70,6 @@ def read_organizer(event):
     if 'cn' in organizer.params:
         name = organizer.params['cn']
 
-    mailto_href = ''.format(email, name)
     return {"name": name, "email": email}
 
 def read_calendar(cal):
@@ -94,12 +93,14 @@ def read_calendar(cal):
 
 def format_location_html(event):
     lc = event['location'].lower()
+    location = event['location']
+    html = event['location']
     if lc.startswith("http://") or lc.startswith("https://"):
-        return f'<a href="{lc}">{event["location"]}</a>'
+        html = f"""<a href="{lc}">{location}</a>"""
     elif lc.find("slack") or lc.find('#flux'):
-        return f'<a href="https://cloud-native.slack.com/messages/flux">{event["location"]}</a>'
-    else:
-        return event['location']
+        html = f"""<a href="https://cloud-native.slack.com/messages/flux">{location}</a>"""
+    return html
+
 
 def write_events_html(events):
     if os.path.exists(CALENDAR_INCLUDE_HTML):

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,7 +1,12 @@
 {{ if isset .Site.Params "algolia_docsearch" }}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+
 {{ $tabs := resources.Get "js/tabs.js" | js.Build "tabs.js" }}
 <script type="text/javascript" src="{{ $tabs.RelPermalink }}" defer></script>
+
+{{ $calendar := resources.Get "js/calendar.js" | js.Build "calendar.js" }}
+<script type="text/javascript" src="{{ $calendar.RelPermalink }}" defer></script>
+
 <script type="text/javascript"> docsearch({
 apiKey: '45f9f14d53600b0a2cafa46a26ee10f4',
 indexName: 'fluxcd',


### PR DESCRIPTION
Instead of mousenter/mouseleave I'm using clicks on the calendar items to activate. This works with both touchscreen and mouse cursor devices. Please review the import-calendar.py changes. I'm doing some data cleaning up that maybe could be avoided by changing calendar data contents, but it should work and look neat with the existing data now. 