### PR TITLE
Fix adopters carousel horizontal overflow scrollbar

### DIFF
--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -18,6 +18,11 @@
   }
 }
 
+html {
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+
 // center section contents and limit width for ultra-wide screens
 main.td-main {
   section.row {
@@ -172,17 +177,6 @@ h2.section-label {
     padding-top: 2rem !important;
   }
 
-  .td-box--9 {
-    background-color: $flux-gray;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cpath fill='%234f4f4f' fill-opacity='0.43' d='M1 3h1v1H1V3zm2-2h1v1H3V1z'%3E%3C/path%3E%3C/svg%3E");
-
-    padding: 1rem 0 4rem 0;
-
-    .td-arrow-down::before {
-      border-color: $flux-gray transparent transparent transparent;
-    }
-  }
-
   section.row.td-box > .col > .row {
     margin: 0;
     padding: 0;
@@ -211,10 +205,6 @@ h2.section-label {
         text-align:left;
       }
     }
-  }
-
-  section.td-box--7 {
-    background-color: $flux-dark-blue;
   }
 
   .td-arrow-down::before {


### PR DESCRIPTION
100vw required for the carousel layout was sometimes producing a small empty margin on the right side of the page. This is an artifact of the browser calculation of viewport width when a vertical scrollbar is present. Hide horizontal scrollbar as a workaround. 

