### PR TITLE
bring back hamburger icon in mobile docs

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -8,6 +8,14 @@
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
+  {{ else -}}
+  <div id="content-mobile">
+  <form class="td-sidebar__search d-flex align-items-center">
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  </div>
+  <div id="content-desktop"></div>
   {{ end -}}
   <nav class="collapse td-sidebar-nav{{ if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" id="td-section-nav">
     {{ if  (gt (len .Site.Home.Translations) 0) -}}


### PR DESCRIPTION
I was over-eager in #505 and removed the :hamburger: icon in mobile docs.

The actual diff over upstream `docsy` in our `sidebar-tree.html` is even smaller now:

```cli
❯ diff -u {themes/docsy/,}layouts/partials/sidebar-tree.html 
--- themes/docsy/layouts/partials/sidebar-tree.html	2021-07-20 18:13:59.000000000 +0200
+++ layouts/partials/sidebar-tree.html	2021-09-10 14:47:56.666177455 +0200
@@ -11,7 +11,6 @@
   {{ else -}}
   <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
-    {{ partial "search-input.html" . }}
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>


```
