### PR TITLE
Create seprate install guides for Linux, Mac and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,19 @@ static/img/logos
 
 # local GH token, used for some scripts
 .gh-token
+
+# Imported snippets
+static/snippet/docs/install/curlchecksum.sh
+static/snippet/docs/install/curldarwin_amd64.sh
+static/snippet/docs/install/curldarwin_arm64.sh
+static/snippet/docs/install/curllinux_amd64.sh
+static/snippet/docs/install/curlwindows_amd64.ps1
+static/snippet/docs/install/tardarwin_amd64.sh
+static/snippet/docs/install/tardarwin_arm64.sh
+static/snippet/docs/install/tarlinux_amd64.sh
+static/snippet/docs/install/verifydarwin_amd64.sh
+static/snippet/docs/install/verifydarwin_arm64.sh
+static/snippet/docs/install/verifylinux_amd64.sh
+static/snippet/docs/install/verifywindows_amd64.ps1
+static/snippet/docs/install/zipwindows_amd64.ps1
+static/snippet/docs/latestrelease.md

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ gen-content: ## Generates content from external sources.
 	hack/gen-content.py
 	hack/import-calendar.py
 	hack/import-flux2-assets.sh
+	hack/get-release.sh
 
 serve: gen-content theme ## Spawns a development server.
 	hugo server \

--- a/content/en/docs/guides/install/_index.md
+++ b/content/en/docs/guides/install/_index.md
@@ -1,0 +1,38 @@
+---
+title: "Install the Flux CLI"
+linkTitle: "Install the Flux CLI"
+description: "Flux install, bootstrap, upgrade and uninstall documentation."
+no_list: true
+weight: 41
+---
+
+The Flux command-line tool, flux , allows you to 
+
+- Bootstrap Flux onto a cluster
+- Generate Flux resource definitions
+- Monitor flux components and resources
+
+For more information including a complete list of flux operations, see the [`flux` reference documentation](../../cmd/_index.md).
+
+The Flux CLI is installable on a variety of Linux platforms, macOS and Windows. Find your preferred operating system below.
+
+- [Install the Flux CLI on Linux](linux.md)
+- [Install the Flux CLI on macOS](osx.md)
+- [Install the Flux CLI on Windows](windows.md)
+
+## Binaries
+
+The Flux CLI is available as a binary executable for all major platforms. Binaries can be downloaded from GitHub
+[releases page](https://github.com/fluxcd/flux2/releases). 
+
+Links to the binaries for the latest release are provided below.
+
+{{< readFile file="static/snippet/docs/latestrelease.md" markdown="true" >}}
+
+
+## Container Image
+
+A container image with `kubectl` and `flux` is available on DockerHub and GitHub:
+
+* `docker.io/fluxcd/flux-cli:<version>`
+* `ghcr.io/fluxcd/flux-cli:<version>`

--- a/content/en/docs/guides/install/linux.md
+++ b/content/en/docs/guides/install/linux.md
@@ -1,0 +1,86 @@
+---
+title: "Install the Flux CLI on Linux"
+linkTitle: "Install the Flux CLI on Linux"
+description: "Flux install, bootstrap, upgrade and uninstall documentation."
+---
+
+## Install using package management
+
+{{% tabs %}}
+{{% tab "Homebrew" %}}
+
+  {{< readFile file="static/snippet/docs/install/homebrew.md" markdown="true" >}}
+
+{{% /tab %}}
+{{% tab "yay" %}}
+
+With [yay](https://github.com/Jguer/yay) (or another [AUR helper](https://wiki.archlinux.org/title/AUR_helpers)) for Arch Linux:
+
+```sh
+yay -S flux-bin
+```
+
+{{% /tab %}}
+{{% tab "GoFish" %}}
+
+  {{< readFile file="static/snippet/docs/install/gofish.md" markdown="true" >}}
+
+{{% /tab %}}
+{{% tab "nix-env" %}}
+
+With [nix-env](https://nixos.org/manual/nix/unstable/command-ref/nix-env.html):`
+
+```sh
+nix-env -f channel:nixos-unstable -iA fluxcd
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+## Install using curl
+
+1. Download the latest release with the command:
+
+    {{< readFile file="static/snippet/docs/install/curllinux.md" markdown="true" >}}
+
+1. Validate the archive (optional)
+
+    Download the checksum file:
+
+    {{< readFile file="static/snippet/docs/install/downloadchecksum.md" markdown="true" >}}
+
+    Validate the flux archive against the checksum file
+
+    {{< readFile file="static/snippet/docs/install/verifychecksumlinux.md" markdown="true" >}}
+
+    If valid, the output is similar to:
+
+    ```bash
+    flux_0.17.0_linux_amd64.tar.gz: OK
+    ```
+
+    If the check fails, ``sha256sum`` exits with nonzero status and prints output similar to:
+
+    ```bash
+    flux_0.17.0_linux_amd64.tar.gz: no file was verified
+    ```
+
+2. Extract the binary
+
+    {{< readFile file="static/snippet/docs/install/extractlinux.md" markdown="true" >}}
+
+3. Install Flux
+
+    ```bash
+    sudo install -o root -g root -m 0755 flux /usr/local/bin/flux
+    ```
+
+4. Verify installation
+
+    ```bash
+    flux --version
+    ```
+
+## shell autocomplete
+
+{{< readFile file="static/snippet/docs/install/autocomplete.md" markdown="true" >}}

--- a/content/en/docs/guides/install/linux.md
+++ b/content/en/docs/guides/install/linux.md
@@ -41,17 +41,17 @@ nix-env -f channel:nixos-unstable -iA fluxcd
 
 1. Download the latest release with the command:
 
-    {{< readFile file="static/snippet/docs/install/curllinux.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/curllinux_amd64.sh" language="bash" >}}
 
-1. Validate the archive (optional)
+2. Validate the archive (optional)
 
     Download the checksum file:
 
-    {{< readFile file="static/snippet/docs/install/downloadchecksum.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/curlchecksum.sh" language="bash" >}}
 
     Validate the flux archive against the checksum file
 
-    {{< readFile file="static/snippet/docs/install/verifychecksumlinux.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/verifylinux_amd64.sh" language="bash" >}}
 
     If valid, the output is similar to:
 
@@ -65,17 +65,17 @@ nix-env -f channel:nixos-unstable -iA fluxcd
     flux_0.17.0_linux_amd64.tar.gz: no file was verified
     ```
 
-2. Extract the binary
+3. Extract the binary
 
-    {{< readFile file="static/snippet/docs/install/extractlinux.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/tarlinux_amd64.sh" language="bash" >}}
 
-3. Install Flux
+4. Install Flux
 
     ```bash
     sudo install -o root -g root -m 0755 flux /usr/local/bin/flux
     ```
 
-4. Verify installation
+5. Verify installation
 
     ```bash
     flux --version

--- a/content/en/docs/guides/install/osx.md
+++ b/content/en/docs/guides/install/osx.md
@@ -21,17 +21,17 @@ description: "Flux install, bootstrap, upgrade and uninstall documentation."
 
 ## Install using curl
 
-1. Download the latest release:
+1. Download the latest release using ``curl``:
 
   {{% tabs %}}
   {{% tab "Intel" %}}
 
-  {{< readFile file="static/snippet/docs/install/curlosxintel.md" markdown="true" >}}
+  {{< codeblock file="static/snippet/docs/install/curldarwin_amd64.sh" language="bash" >}}
 
   {{% /tab %}}
   {{% tab "Apple Silicon" %}}
 
-  {{< readFile file="static/snippet/docs/install/curlosxarm.md" markdown="true" >}}
+  {{< codeblock file="static/snippet/docs/install/curldarwin_arm64.sh" language="bash" >}}
 
   {{% /tab %}}
   {{% /tabs %}}
@@ -40,19 +40,19 @@ description: "Flux install, bootstrap, upgrade and uninstall documentation."
 
   Download the flux checksum file:
 
-  {{< readFile file="static/snippet/docs/install/downloadchecksum.md" markdown="true" >}}
+  {{< codeblock file="static/snippet/docs/install/curlchecksum.sh" language="bash" >}}
 
   Validate the archive against the checksum file:
 
   {{% tabs %}}
   {{% tab "Intel" %}}
 
-  {{< readFile file="static/snippet/docs/install/verifychecksumosxintel.md" markdown="true" >}}
+  {{< codeblock file="static/snippet/docs/install/verifydarwin_amd64.sh" language="bash" >}}
 
   {{% /tab %}}
   {{% tab "Apple Silicon" %}}
 
-  {{< readFile file="static/snippet/docs/install/verifychecksumosxarm.md" markdown="true" >}}
+  {{< codeblock file="static/snippet/docs/install/verifydarwin_arm64.sh" language="bash" >}}
 
   {{% /tab %}}
   {{% /tabs %}}
@@ -69,17 +69,17 @@ description: "Flux install, bootstrap, upgrade and uninstall documentation."
   flux_0.17.0_darwin_amd64.tar.gz: no file was verified
   ```
 
-3. Extract the archive
+3. Extract the archive with ``tar``:
 
   {{% tabs %}}
   {{% tab "Intel" %}}
 
-  {{< readFile file="static/snippet/docs/install/extractosxintel.md" markdown="true" >}}
+  {{< codeblock file="static/snippet/docs/install/tardarwin_amd64.sh" language="bash" >}}
 
   {{% /tab %}}
   {{% tab "Apple Silicon" %}}
 
-  {{< readFile file="static/snippet/docs/install/extractosxarm.md" markdown="true" >}}
+  {{< codeblock file="static/snippet/docs/install/tardarwin_arm64.sh" language="bash" >}}
 
   {{% /tab %}}
   {{% /tabs %}}
@@ -93,7 +93,9 @@ description: "Flux install, bootstrap, upgrade and uninstall documentation."
 
 5. Verify installation
 
-  ```flux --version```
+  ```bash
+  flux --version
+  ```
 
 ## Enable shell autocompletion
 

--- a/content/en/docs/guides/install/osx.md
+++ b/content/en/docs/guides/install/osx.md
@@ -1,0 +1,100 @@
+---
+title: "Install the Flux CLI on Mac"
+linkTitle: "Install the Flux CLI on Mac"
+description: "Flux install, bootstrap, upgrade and uninstall documentation."
+---
+
+## Install using a package manager
+
+{{% tabs %}}
+{{% tab "Homebrew" %}}
+
+  {{< readFile file="static/snippet/docs/install/homebrew.md" markdown="true" >}}
+
+{{% /tab %}}
+{{% tab "GoFish" %}}
+
+  {{< readFile file="static/snippet/docs/install/gofish.md" markdown="true" >}}
+
+{{% /tab %}}
+{{% /tabs %}}
+
+## Install using curl
+
+1. Download the latest release:
+
+  {{% tabs %}}
+  {{% tab "Intel" %}}
+
+  {{< readFile file="static/snippet/docs/install/curlosxintel.md" markdown="true" >}}
+
+  {{% /tab %}}
+  {{% tab "Apple Silicon" %}}
+
+  {{< readFile file="static/snippet/docs/install/curlosxarm.md" markdown="true" >}}
+
+  {{% /tab %}}
+  {{% /tabs %}}
+
+2. Validate the archive (optional)
+
+  Download the flux checksum file:
+
+  {{< readFile file="static/snippet/docs/install/downloadchecksum.md" markdown="true" >}}
+
+  Validate the archive against the checksum file:
+
+  {{% tabs %}}
+  {{% tab "Intel" %}}
+
+  {{< readFile file="static/snippet/docs/install/verifychecksumosxintel.md" markdown="true" >}}
+
+  {{% /tab %}}
+  {{% tab "Apple Silicon" %}}
+
+  {{< readFile file="static/snippet/docs/install/verifychecksumosxarm.md" markdown="true" >}}
+
+  {{% /tab %}}
+  {{% /tabs %}}
+
+  If valid, the output is similar to:
+
+  ```bash
+  flux_0.17.0_darwin_amd64.tar.gz: OK
+  ```
+
+  If the check fails, ``sha256sum`` exits with nonzero status and prints output similar to:
+
+  ```bash
+  flux_0.17.0_darwin_amd64.tar.gz: no file was verified
+  ```
+
+3. Extract the archive
+
+  {{% tabs %}}
+  {{% tab "Intel" %}}
+
+  {{< readFile file="static/snippet/docs/install/extractosxintel.md" markdown="true" >}}
+
+  {{% /tab %}}
+  {{% tab "Apple Silicon" %}}
+
+  {{< readFile file="static/snippet/docs/install/extractosxarm.md" markdown="true" >}}
+
+  {{% /tab %}}
+  {{% /tabs %}}
+
+4. Move the flux Binary to a file location on your system ``PATH``.
+
+  ```bash
+  sudo mv ./flux /usr/local/bin/flux
+  sudo chown root: /usr/local/bin/flux
+  ```
+
+5. Verify installation
+
+  ```flux --version```
+
+## Enable shell autocompletion
+
+{{< readFile file="static/snippet/docs/install/autocomplete.md" markdown="true" >}}

--- a/content/en/docs/guides/install/windows.md
+++ b/content/en/docs/guides/install/windows.md
@@ -27,17 +27,17 @@ choco install flux
 
 1. Download the latest release
 
-    {{< readFile file="static/snippet/docs/install/curlwindowsamd.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/curlwindows_amd64.ps1" language="powershell" >}}
 
 1. Validate the archive (optional)
 
     Download the checksum file
 
-    {{< readFile file="static/snippet/docs/install/downloadchecksum.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/curlchecksum.sh" language="powershell" >}}
 
     Validate the archive against the checksum file
 
-    {{< readFile file="static/snippet/docs/install/verifychecksumwin.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/verifywindows_amd64.ps1" language="powershell" >}}
     
     If valid, the output is similar to:
 
@@ -49,7 +49,7 @@ choco install flux
 
 2. Extract the binary
 
-    {{< readFile file="static/snippet/docs/install/extractwinamd.md" markdown="true" >}}
+    {{< codeblock file="static/snippet/docs/install/zipwindows_amd64.ps1" language="powershell" >}}
 
 3. Add the binary in to your ``PATH``.
 

--- a/content/en/docs/guides/install/windows.md
+++ b/content/en/docs/guides/install/windows.md
@@ -1,0 +1,58 @@
+---
+title: "Install the Flux CLI on Windows"
+linkTitle: "Install the Flux CLI Windows"
+description: "Flux install, bootstrap, upgrade and uninstall documentation."
+---
+
+## Install using a package manager
+
+{{% tabs %}}
+{{% tab "Chocolatey" %}}
+
+With [Chocolatey](https://chocolatey.org/):
+
+```powershell
+choco install flux
+```
+
+{{% /tab %}}
+{{% tab "GoFish" %}}
+
+  {{< readFile file="static/snippet/docs/install/gofish.md" markdown="true" >}}
+
+{{% /tab %}}
+{{% /tabs %}}
+
+## Install using curl
+
+1. Download the latest release
+
+    {{< readFile file="static/snippet/docs/install/curlwindowsamd.md" markdown="true" >}}
+
+1. Validate the archive (optional)
+
+    Download the checksum file
+
+    {{< readFile file="static/snippet/docs/install/downloadchecksum.md" markdown="true" >}}
+
+    Validate the archive against the checksum file
+
+    {{< readFile file="static/snippet/docs/install/verifychecksumwin.md" markdown="true" >}}
+    
+    If valid, the output is similar to:
+
+    ```bash
+    flux_0.17.0_checksums.txt:4:4f4f9bf34e691d85bad7b0752a0c5471ec665a69d538569daab2b6239a54d83c  flux_0.17.0_windows_amd64.zip
+    ```
+
+    If the check fails, no output is displayed.
+
+2. Extract the binary
+
+    {{< readFile file="static/snippet/docs/install/extractwinamd.md" markdown="true" >}}
+
+3. Add the binary in to your ``PATH``.
+
+## Enable shell autocompletion
+
+{{< readFile file="static/snippet/docs/install/autocomplete.md" markdown="true" >}}

--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -5,85 +5,13 @@ description: "Flux install, bootstrap, upgrade and uninstall documentation."
 weight: 30
 ---
 
-This guide walks you through setting up Flux to
-manage one or more Kubernetes clusters.
+## Installation
 
-## Prerequisites
+The Flux CLI is installable on a variety of Linux platforms, macOS and Windows. Find your preferred operating system below.
 
-You will need a Kubernetes cluster version **1.16** or newer
-and kubectl version **1.18** or newer.
-
-## Install the Flux CLI
-
-{{% tabs %}}
-{{% tab "Homebrew" %}}
-
-With [Homebrew](https://brew.sh) for macOS and Linux:
-
-```sh
-brew install fluxcd/tap/flux
-```
-
-{{% /tab %}}
-{{% tab "GoFish" %}}
-
-With [GoFish](https://gofi.sh) for Windows, macOS and Linux:
-
-```sh
-gofish install flux
-```
-
-{{% /tab %}}
-{{% tab "bash" %}}
-
-With [Bash](https://www.gnu.org/software/bash/) for macOS and Linux:
-
-```sh
-curl -s https://fluxcd.io/install.sh | sudo bash
-```
-
-{{% /tab %}}
-{{% tab "yay" %}}
-
-With [yay](https://github.com/Jguer/yay) (or another [AUR helper](https://wiki.archlinux.org/title/AUR_helpers)) for Arch Linux:
-
-```sh
-yay -S flux-bin
-```
-
-{{% /tab %}}
-{{% tab "nix" %}}
-
-With [nix-env](https://nixos.org/manual/nix/unstable/command-ref/nix-env.html) for NixOS:
-
-```sh
-nix-env -i fluxcd
-```
-{{% /tab %}}
-{{% /tabs %}}
-
-Binaries for **macOS**, **Windows** and **Linux** AMD64/ARM are available for download on the
-[release page](https://github.com/fluxcd/flux2/releases).
-
-To configure your shell to load `flux` [bash completions](./cmd/flux_completion_bash.md) add to your profile:
-
-```sh
-# ~/.bashrc or ~/.bash_profile
-. <(flux completion bash)
-```
-
-[`zsh`](./cmd/flux_completion_zsh.md), [`fish`](./cmd/flux_completion_fish.md), and [`powershell`](./cmd/flux_completion_powershell.md) are also supported with their own sub-commands.
-
-A container image with `kubectl` and `flux` is available on DockerHub and GitHub:
-
-* `docker.io/fluxcd/flux-cli:<version>`
-* `ghcr.io/fluxcd/flux-cli:<version>`
-
-Verify that your cluster satisfies the prerequisites with:
-
-```sh
-flux check --pre
-```
+- [Install the Flux CLI on Linux](linux.md)
+- [Install the Flux CLI on macOS](osx.md)
+- [Install the Flux CLI on Windows](windows.md)
 
 ## Bootstrap
 

--- a/hack/get-release.sh
+++ b/hack/get-release.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -x
-
 list=$(curl --silent "https://api.github.com/repos/fluxcd/flux2/releases/latest" | jq -r '.assets[] | select(.name | test("^.*(flux_).*$")).browser_download_url')
 snippet_loc="static/snippet/docs/install"
 rel_loc="static/snippet/docs/latestrelease.md"

--- a/hack/get-release.sh
+++ b/hack/get-release.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/bash
+
+list=($(curl --silent "https://api.github.com/repos/fluxcd/flux2/releases/latest" | jq -r '.assets[] | select(.name | test("^.*(flux_).*$")).browser_download_url'))
+
+echo "| Download URL | Platform |" > static/snippet/docs/latestrelease.md
+echo "| ------------ | ------------ |" >> static/snippet/docs/latestrelease.md
+validatelinux=""
+validateosxintel=""
+validateosxarm=""
+validatechecksum=""
+validatechecksumwin=""
+validatewin=""
+for i in "${list[@]}"; do
+    filename=$(echo $i | grep -o -P '(\w+)(\.\w+)+(?!.*(\w+)(\.\w+)+)')
+    if [[ $i != *checksums* ]]; then
+      arch=$(echo $i | grep -o -P '(?<=[0-9]_).*(?=.tar.gz)')$(echo $i | grep -o -P '(?<=[0-9]_).*(?=.zip)')
+      printf "| $i | $arch |\n" >> static/snippet/docs/latestrelease.md
+      if [[ $i == *linux_amd64* ]]; then
+        printf "\`\`\`bash\ncurl -LO \"$i\"\n\`\`\`\n" > static/snippet/docs/install/curllinux.md
+        printf "\`\`\`bash\ntar -xzof $filename\n\`\`\`\n" > static/snippet/docs/install/extractlinux.md
+        validatelinux=$(printf "\`\`\`bash\nsha256sum $filename -c ")
+      elif [[ $i == *darwin_amd64* ]]; then
+        printf "\`\`\`bash\ncurl -LO \"$i\"\n\`\`\`\n" > static/snippet/docs/install/curlosxintel.md
+        printf "\`\`\`bash\ntar -xzof $filename\n\`\`\`\n" > static/snippet/docs/install/extractosxintel.md
+        validateosxintel=$(printf "\`\`\`bash\nsha256sum $filename -c ")
+      elif [[ $i == *darwin_arm64* ]]; then
+        printf "\`\`\`bash\ncurl -LO \"$i\"\n\`\`\`\n" > static/snippet/docs/install/curlosxarm.md
+        printf "\`\`\`bash\ntar -xzof $filename\n\`\`\`\n" > static/snippet/docs/install/extractosxarm.md
+        validateosxarm=$(printf "\`\`\`bash\nsha256sum $filename -c ")
+      elif [[ $i == *windows_amd64* ]]; then
+        printf "\`\`\`bash\ncurl -LO \"$i\"\n\`\`\`\n" > static/snippet/docs/install/curlwindowsamd.md
+        validatewinfile=$(printf "$filename")
+        printf "\`\`\`powershell\nExpand-Archive -Path $filename -DestinationPath .\n\`\`\`\n" > static/snippet/docs/install/extractwinamd.md
+      fi
+    else
+      printf "\`\`\`bash\ncurl -LO \"$i\"\n\`\`\`\n" > static/snippet/docs/install/downloadchecksum.md
+      
+      validatechecksum=$(printf "$filename --ignore-missing\n\`\`\`\n")
+      validatechecksumfilewin=$(printf "$filename")
+    fi
+done
+
+printf "$validatelinux$validatechecksum" > static/snippet/docs/install/verifychecksumlinux.md
+printf "$validateosxintel$validatechecksum" > static/snippet/docs/install/verifychecksumosxintel.md
+printf "$validateosxarm$validatechecksum" > static/snippet/docs/install/verifychecksumosxarm.md
+printf "\`\`\`powershell\nSelect-String -Path $validatechecksumfilewin -Pattern ((Get-FileHash '$validatewinfile').Hash)\n\`\`\`\n" > static/snippet/docs/install/verifychecksumwin.md

--- a/layouts/shortcodes/readFile.html
+++ b/layouts/shortcodes/readFile.html
@@ -1,0 +1,8 @@
+{{$file := .Get "file"}}
+{{- if eq (.Get "markdown") "true" -}}
+{{- $file  | readFile | markdownify -}}
+{{- else if  (.Get "highlight") -}}
+{{-  highlight ($file  | readFile) (.Get "highlight") "" -}}
+{{- else -}}
+{{ $file  | readFile | safeHTML }}
+{{- end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "make production-build"
 
 [build.environment]
-  HUGO_VERSION = "0.86.0"
+  HUGO_VERSION = "0.88.1"
 
 [context.production.environment]
   HUGO_ENV = "production"

--- a/static/snippet/docs/install/autocomplete.md
+++ b/static/snippet/docs/install/autocomplete.md
@@ -1,0 +1,8 @@
+To configure your shell to load `flux` [bash completions](./cmd/flux_completion_bash.md) add to your profile:
+
+```sh
+. <(flux completion bash)
+```
+[`zsh`](./cmd/flux_completion_zsh.md), [`fish`](./cmd/flux_completion_fish.md),
+and [`powershell`](./cmd/flux_completion_powershell.md)
+are also supported with their own sub-commands.

--- a/static/snippet/docs/install/gofish.md
+++ b/static/snippet/docs/install/gofish.md
@@ -1,0 +1,5 @@
+With [GoFish](https://gofi.sh):
+
+```sh
+gofish install flux
+```

--- a/static/snippet/docs/install/homebrew.md
+++ b/static/snippet/docs/install/homebrew.md
@@ -1,0 +1,5 @@
+With [Homebrew](https://brew.sh):
+
+```sh
+brew install fluxcd/tap/flux
+```


### PR DESCRIPTION
- Adds script get-release.sh
    - Creates snippets for install guides
    - Creates table with links to release download
- Adds shortcode for importing content from another markdown file
- Adds manual binary install method
- Removes bash script install method

Signed-off-by: Alison Dowdney <alison@alisondowdney.com>