### PR TITLE
Add manual trigger targets for (support) docker image builds

### DIFF
--- a/.github/workflows/build-push-hugo-image.yml
+++ b/.github/workflows/build-push-hugo-image.yml
@@ -1,0 +1,44 @@
+name: Push updated Docker hugo version
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hugo-image:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_FLUXCD_USER }}
+          password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
+      -
+        name: Checkout repo
+        uses: actions/checkout@v2
+      -
+        name: Set repo_owner variable
+        run: make --silent print-repo-owner >> $GITHUB_ENV
+      -
+        name: Set hugo_version variable
+        run: make --silent print-hugo-version >> $GITHUB_ENV
+      -
+        name: Clone hugo repo
+        run: make hugo
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: hugo
+          push: true
+          build-args: |
+            HUGO_VERSION=${{ env.hugo_version }}
+            HUGO_BUILD_TAGS=extended
+          tags: ${{ env.repo_owner }}/website:hugo-${{ env.hugo_version }}-extended

--- a/.github/workflows/build-push-hugo-support.yml
+++ b/.github/workflows/build-push-hugo-support.yml
@@ -1,0 +1,40 @@
+name: Push updated hugo support image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hugo-support:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_FLUXCD_USER }}
+          password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
+      -
+        name: Checkout repo
+        uses: actions/checkout@v2
+      -
+        name: Set repo_owner variable
+        run: make --silent print-repo-owner >> $GITHUB_ENV
+      -
+        name: Set hugo_version variable
+        run: make --silent print-hugo-version >> $GITHUB_ENV
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          build-args: |
+            HUGO_VERSION=${{ env.hugo_version }}
+          tags: ${{ env.repo_owner }}/website:hugo-support

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apk update && \
 COPY requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt
 RUN ln -s `which python3` /usr/bin/python
+RUN npm i
 
 # VOLUME /site	# provided by upstream
 # WORKDIR /site

--- a/Makefile
+++ b/Makefile
@@ -129,3 +129,9 @@ hugo:
 .PHONY: lychee-docker
 lychee-docker: gen-content
 	docker run --rm -it -e "GITHUB_TOKEN=$GITHUB_TOKEN" -v $$(pwd):/app $(LYCHEE_IMAGE_NAME) "/app/**/*.md"
+
+print-hugo-version:
+	echo hugo_version=$(HUGO_VERSION)
+
+print-repo-owner:
+	echo repo_owner=$(DEV_IMAGE_REGISTRY_NAME)


### PR DESCRIPTION
Fixes #522

This PR will make the `docker-push-hugo` and `docker-push-support` targets triggerable as `workflow_dispatch` actions, through the Github Actions workflow tab on GitHub.

I tested this out on the `kingdon` branch of same fork of the website repo, the results are here: https://hub.docker.com/r/kingdonb/website/tags?page=1&ordering=last_updated

You can set `image: kingdonb/website:hugo-support` in `okteto.yml` and run `okteto up` to see this in action right now (the rebuilt image is what is required to make the `okteto up` or `make docker-serve` targets function properly)