### PR TITLE
Fix target namespace arg in get started guide

### DIFF
--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -157,7 +157,7 @@ directory located in the podinfo repository.
 
     ```sh
     flux create kustomization podinfo \
-      --targetNamespace=default \
+      --target-namespace=default \
       --source=podinfo \
       --path="./kustomize" \
       --prune=true \


### PR DESCRIPTION
Fix: #579 