### PR TITLE
Revert "Point to all of our events in October"

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -7,8 +7,8 @@ description: >
   Now is the best time to start using Flux, or start your migration if you are a legacy user.
 ---
 
-{{% blocks/celebration emoji="📢" url="/blog/2021/10/october-2021-update/#upcoming-events" %}}
-Catch Flux maintainers and GitOps practitioners at events in October!
+{{% blocks/celebration emoji="📢" url="/blog/2021/09/gitops-one-stop-shop/" %}}
+Oct 20th: Join us at the GitOps One-Stop Shop Event!
 {{% /blocks/celebration %}}
 
 <div class="hero-gitops">


### PR DESCRIPTION
Reverts fluxcd/website#569

Now that KubeCon is over, we can point to the original event post again (until after Oct 20).