### PR TITLE
Fix FAQ example

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -197,6 +197,7 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
   name: coredns
   namespace: kube-system
+spec:
   selector:
     matchLabels:
       eks.amazonaws.com/component: coredns


### PR DESCRIPTION
The FAQ has an example about updating base Kubernetes manifests. I updated the example to add a top level `spec`.