### PR TITLE
Improve vertical alignment for navbar items

### DIFF
--- a/assets/scss/blocks/_nav.scss
+++ b/assets/scss/blocks/_nav.scss
@@ -27,6 +27,8 @@ nav.navbar {
       font-size: 1rem;
       text-transform: none;
       font-weight: 700;
+
+      margin-top: 3px;
     }
   }
 
@@ -38,6 +40,11 @@ nav.navbar {
       border: none;
       max-width: 11rem;
       padding-left: 9px;
+      padding-top: 12px;
+      @include media-breakpoint-down(md) {
+        padding-top: 10px;
+      }
+
       margin-right: 1rem;
     }
   }


### PR DESCRIPTION
Vertically align navbar item text to the logo "Flux" center line

from:
![image](https://user-images.githubusercontent.com/4100/139106331-7c097e0b-fb17-488d-b2a2-95f28af6129b.png)


to:
![image](https://user-images.githubusercontent.com/4100/139106222-f9b04d9f-f68f-4800-9f48-ca1a7cd4ac20.png)
