### PR TITLE
sops: Use minimal, decrypt-only policy for AWS

### DIFF
--- a/content/en/docs/guides/mozilla-sops.md
+++ b/content/en/docs/guides/mozilla-sops.md
@@ -205,10 +205,7 @@ Create an IAM Role with access to AWS KMS e.g.:
     "Statement": [
         {
             "Action": [
-                "kms:Encrypt",
                 "kms:Decrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
                 "kms:DescribeKey"
             ],
             "Effect": "Allow",
@@ -217,6 +214,12 @@ Create an IAM Role with access to AWS KMS e.g.:
     ]
 }
 ```
+
+{{% alert color="info" title="Hint" %}}
+The above policy represents the minimal permissions needed for the controller
+to be able to decrypt secrets. Policies for users/clients who are meant to be encrypting and managing
+secrets will additionally require the `kms:Encrypt`, `kms:ReEncrypt*` and `kms:GenerateDataKey*` actions.
+{{% /alert %}}
 
 Bind the IAM role to the `kustomize-controller` service account:
 


### PR DESCRIPTION
The example IAM policy for AWS KMS integration is too wide for kustomize-controller which only really needs describe and decrypt. 

I've tested this by changing the policy in our dev environment, deleting a secret and seeing it be successfully applied the next reconcile.