### PR TITLE
Explain how to activate ImageAutomationPolicy

### DIFF
--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -364,6 +364,12 @@ The image policy marker format is:
 * `{"$imagepolicy": "<policy-namespace>:<policy-name>:tag"}`
 * `{"$imagepolicy": "<policy-namespace>:<policy-name>:name"}`
 
+These markers are placed inline in the target YAML, as a comment.  The "Setter" strategy refers to
+[kyaml setters](https://github.com/fluxcd/flux2/discussions/107#discussioncomment-82746)
+which Flux can find and replace during reconciliation, when directed to do so by an `ImageAutomationPolicy` 
+like the one above.
+
+Here are some examples of using this marker in a variety of Kubernetes resources.
 
 `HelmRelease` example:
 


### PR DESCRIPTION
As a Flux 1 user, we did not have these abstractions, and no comments were needed. 

This is better! 

I was aware of neither kyaml nor any other approach to comment templating on Kubernetes,  

This paragraph would have helped me, and I think it can help others. 