### PR TITLE
Update to most recent Hugo and Docsy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 BLOCK_STDOUT_CMD           := python -c "import os,sys,fcntl; \
                                            flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); \
                                            fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);"
-DOCSY_COMMIT 			   ?= f8d5a5eb9d1c5aecd253da8b8685a9251e6b253a
+DOCSY_COMMIT 			   ?= 6f95d15416ff2e336bd1e9291f797a654f7c32ce
 DOCSY_COMMIT_FOLDER        := docsy-$(DOCSY_COMMIT)
 DOCSY_TARGET               := themes/$(DOCSY_COMMIT_FOLDER)
 BOOTSTRAP_SEMVER           ?= 4.6.0

--- a/content/en/blog/2021-10-29-november-update.md
+++ b/content/en/blog/2021-10-29-november-update.md
@@ -242,7 +242,7 @@ between Stefan Prodan, one of our Flux maintainers and Chris Wright, the
 Red Hat CTO. They cover GitOps from various interesting angles. It's
 certainly worth your time.
 
-{{< tweet 1453353304101203977 >}}
+{{< tweet user=RedHat id=1453353304101203977 >}}
 
 ## In other news
 

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,43 +1,57 @@
 {{ if .Path }}
-  {{ $pathFormatted := replace .Path "\\" "/" }}
-  {{ $gh_repo := ($.Param "github_repo") }}
-  {{ $gh_url := ($.Param "github_url") }}
-  {{ $gh_subdir := ($.Param "github_subdir") }}
-  {{ $gh_project_repo := ($.Param "github_project_repo") }}
-  {{ $gh_branch := (default "master" ($.Param "github_branch")) }}
-  {{ $importedDoc := $.Param "importedDoc" | default "false" }}
-  <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-  {{ if $gh_url }}
-     <a href="{{ $gh_url }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>     
-  {{ else if $gh_repo }}
-    {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}
-    {{ if and ($gh_subdir) (.Site.Language.Lang) }}
-      {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
-    {{ else if .Site.Language.Lang }}
-      {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted }}
-    {{ else if $gh_subdir }}
-      {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
-    {{ end }}
-    {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
-    {{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
-    {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title )}}
-    {{ $newPageStub := resources.Get "stubs/new-page-template.md" }}
-    {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
-    {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
+{{ $pathFormatted := replace .Path "\\" "/" -}}
+{{ $gh_repo := ($.Param "github_repo") -}}
+{{ $gh_url := ($.Param "github_url") -}}
+{{ $gh_subdir := ($.Param "github_subdir") -}}
+{{ $gh_project_repo := ($.Param "github_project_repo") -}}
+{{ $gh_branch := (default "master" ($.Param "github_branch")) -}}
+{{ $importedDoc := $.Param "importedDoc" | default "false" }}
+<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+{{ if $gh_url -}}
+  {{ warnf "Warning: use of `github_url` is deprecated. For details see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
+  <a href="{{ $gh_url }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+{{ else if $gh_repo -}}
+  {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted -}}
+  {{ if and ($gh_subdir) (.Site.Language.Lang) -}}
+    {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted -}}
+  {{ else if .Site.Language.Lang -}}
+    {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted -}}
+  {{ else if $gh_subdir -}}
+    {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted -}}
+  {{ end -}}
 
-    {{ if eq $importedDoc "false" }}
-    <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
-    <a href="{{ $newPageURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
-    {{ end }}
-    <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
-    {{ if $gh_project_repo }}
-      {{ $project_issueURL := printf "%s/issues/new/choose" $gh_project_repo }}
-      <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
-    {{ end }}
+  {{/* Adjust $gh_repo_path based on path_base_for_github_subdir */ -}}
+  {{ $ghs_base := $.Param "path_base_for_github_subdir" -}}
+  {{ $ghs_rename := "" -}}
+  {{ if reflect.IsMap $ghs_base -}}
+    {{ $ghs_rename = $ghs_base.to -}}
+    {{ $ghs_base = $ghs_base.from -}}
+  {{ end -}}
+  {{ with $ghs_base -}}
+    {{ $gh_repo_path = replaceRE . $ghs_rename $gh_repo_path -}}
+  {{ end -}}
 
+  {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
+  {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
+  {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title ) -}}
+  {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
+  {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
+  {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS -}}
+
+  {{ if eq $importedDoc "false" }}
+  <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa fa-file-alt fa-fw"></i> {{ T "post_view_this" }}</a>
+  <a href="{{ $editURL }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+  <a href="{{ $newPageURL }}" class="td-page-meta--child" target="_blank" rel="noopener"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
   {{ end }}
-  {{ with .CurrentSection.AlternativeOutputFormats.Get "print" }}
-    <a id="print" href="{{ .Permalink | safeURL }}"><i class="fa fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
-  {{ end }}
-  </div>
+  <a href="{{ $issuesURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+  {{ with $gh_project_repo -}}
+    {{ $project_issueURL := printf "%s/issues/new" . -}}
+    <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue" target="_blank" rel="noopener"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+  {{ end -}}
+
+{{ end -}}
+{{ with .CurrentSection.AlternativeOutputFormats.Get "print" -}}
+  <a id="print" href="{{ .Permalink | safeURL }}"><i class="fa fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
 {{ end }}
+</div>
+{{ end -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "make production-build"
 
 [build.environment]
-  HUGO_VERSION = "0.88.1"
+  HUGO_VERSION = "0.89.4"
 
 [context.production.environment]
   HUGO_ENV = "production"


### PR DESCRIPTION
Only partial which needed updating was `page-meta-links.html` (our diff is smaller now). Hugo updated its `tweet` shortcode syntax as well.

The diff can be seen here:

```diff
❯ diff -u {../docsy/,}layouts/partials/page-meta-links.html
--- ../docsy/layouts/partials/page-meta-links.html	2021-11-17 13:06:45.619795981 +0100
+++ layouts/partials/page-meta-links.html	2021-11-17 13:10:11.994037432 +0100
@@ -5,6 +5,7 @@
 {{ $gh_subdir := ($.Param "github_subdir") -}}
 {{ $gh_project_repo := ($.Param "github_project_repo") -}}
 {{ $gh_branch := (default "master" ($.Param "github_branch")) -}}
+{{ $importedDoc := $.Param "importedDoc" | default "false" }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ if $gh_url -}}
   {{ warnf "Warning: use of `github_url` is deprecated. For details see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
@@ -37,9 +38,11 @@
   {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
   {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS -}}
 
+  {{ if eq $importedDoc "false" }}
   <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa fa-file-alt fa-fw"></i> {{ T "post_view_this" }}</a>
   <a href="{{ $editURL }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
   <a href="{{ $newPageURL }}" class="td-page-meta--child" target="_blank" rel="noopener"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
+  {{ end }}
   <a href="{{ $issuesURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
   {{ with $gh_project_repo -}}
     {{ $project_issueURL := printf "%s/issues/new" . -}}

website on  update [?] via  v10.24.1 via 🐍 v3.8.10 
❯ 

```
