### PR TITLE
Add Bitbucket Server bootstrap instructions to the install docs

### DIFF
--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -123,12 +123,12 @@ as [multi-arch container images](https://docs.docker.com/docker-for-mac/multi-ar
 with support for Linux `amd64`, `arm64` and `armv7` (e.g. 32bit Raspberry Pi)
 architectures.
 
-If your Git provider is **GitHub**, **GitLab** or **Azure DevOps** please follow the specific bootstrap procedure:
+If your Git provider is **GitHub**, **GitLab**, **Azure DevOps** or **Bitbucket Server** please follow the specific bootstrap procedure:
 
 * [GitHub.com and GitHub Enterprise](#github-and-github-enterprise)
 * [GitLab.com and GitLab Enterprise](#gitlab-and-gitlab-enterprise)
 * [Azure DevOps](../use-cases/azure#flux-installation-for-azure-devops)
-
+* [Bitbucket Server and Data Center](#bitbucket-server-and-data-center)
 ### Generic Git Server
 
 The `bootstrap git` command takes an existing Git repository, clones it and
@@ -328,6 +328,79 @@ flux bootstrap gitlab \
   --owner=my-gitlab-group \
   --repository=my-repository \
   --branch=master \
+  --path=clusters/my-cluster
+```
+
+### Bitbucket Server and Data Center
+
+The `bootstrap bitbucket-server` command creates a Bitbucket Server repository if one doesn't exist and
+commits the Flux components manifests to the specified branch. Then it
+configures the target cluster to synchronize with that repository by
+setting up an SSH deploy key or by using token-based authentication.
+
+{{% alert color="info" title="Bitbucket versions" %}}
+This bootstrap command works with Bitbucket Server and Data Center only because it targets the [1.0](https://developer.atlassian.com/server/bitbucket/reference/rest-api/) REST API. Bitbucket Cloud has migrated to the [2.0](https://developer.atlassian.com/cloud/bitbucket/rest/intro/) REST API.
+{{% /alert %}}
+
+Generate a [personal access token](https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html)
+that grant read/write access to the repository.
+
+Export your Bitbucket personal access token as an environment variable:
+
+```sh
+export BITBUCKET_TOKEN=<your-token>
+```
+
+Run the bootstrap for a repository on your personal Bitbucket Server account:
+
+```sh
+flux bootstrap bitbucket-server \
+  --owner=my-bitbucket-username \
+  --repository=my-repository \
+  --branch=main \
+  --path=clusters/my-cluster \
+  --hostname=my-bitbucket-server.com \
+  --personal
+```
+
+Run the bootstrap for a repository owned by a Bitbucket Server project:
+
+```sh
+flux bootstrap bitbucket-server \
+  --owner=my-bitbucket-project \
+  --username=my-bitbucket-username \
+  --repository=my-repository \
+  --path=clusters/my-cluster \
+  --group=group-name 
+```
+
+When you specify a list of groups, those teams will be granted write access to the repository.
+
+**Note:** The `username` is mandatory for `project` owned repositories. The specified user must own the `BITBUCKET_TOKEN` and have sufficient rights on the target `project` to create repositories.
+
+To run the bootstrap for a repository with a different SSH hostname (e.g. with a different port):
+
+```sh
+flux bootstrap bitbucket-server \
+  --hostname=my-bitbucket-server.com \
+  --ssh-hostname=my-bitbucket-server.com:7999 \
+  --owner=my-bitbucket-project \
+  --username=my-bitbucket-username \
+  --repository=my-repository \
+  --branch=main \
+  --path=clusters/my-cluster
+```
+
+If your Bitbucket Server has SSH access disabled, you can use HTTPS and token authentication with:
+
+```sh
+flux bootstrap bitbucket-server \
+  --token-auth \
+  --hostname=my-bitbucket-server.com \
+  --owner=my-bitbucket-project \
+  --username=my-bitbucket-username \
+  --repository=my-repository \
+  --branch=main \
   --path=clusters/my-cluster
 ```
 


### PR DESCRIPTION
Adds a Bitbucket Server section to the bootstrap doc.

Ref: https://github.com/fluxcd/flux2/pull/2070

Signed-off-by: Soule BA <soule@weave.works>