### PR TITLE
Add Alea to adopters fluxv2

### DIFF
--- a/adopters/1-flux-v2.yaml
+++ b/adopters/1-flux-v2.yaml
@@ -93,3 +93,7 @@ adopters:
     - name: Virginia Tech
       url: https://vt.edu
       logo: logos/virginia-tech.png
+    - name: Alea
+      url: https://www.alea.com
+      logo: logos/alea.png
+            


### PR DESCRIPTION
Signed-off-by: Iñigo Iglesias <inigo.iglesias@alea.com>

Logo already present from flux-v1