### PR TITLE
Use `exported_namespace` in Alertmanager examples

### DIFF
--- a/content/en/docs/guides/monitoring.md
+++ b/content/en/docs/guides/monitoring.md
@@ -127,10 +127,10 @@ groups:
 - name: GitOpsToolkit
   rules:
   - alert: ReconciliationFailure
-    expr: max(gotk_reconcile_condition{status="False",type="Ready"}) by (namespace, name, kind) + on(namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (namespace, name, kind)) * 2 == 1
+    expr: max(gotk_reconcile_condition{status="False",type="Ready"}) by (exported_namespace, name, kind) + on(exported_namespace, name, kind) (max(gotk_reconcile_condition{status="Deleted"}) by (exported_namespace, name, kind)) * 2 == 1
     for: 10m
     labels:
       severity: page
     annotations:
-      summary: '{{ $labels.kind }} {{ $labels.namespace }}/{{ $labels.name }} reconciliation has been failing for more than ten minutes.'
+      summary: '{{ $labels.kind }} {{ $labels.exported_namespace }}/{{ $labels.name }} reconciliation has been failing for more than ten minutes.'
 ```


### PR DESCRIPTION
Show FluxCd object real namespace in alert (exported_namespace) instead of the namespace of the prometheusrule.