### PR TITLE
docs(upgrade-to-ga.md): Flux CD → Flux

### DIFF
--- a/content/en/legacy/helm-operator/how-to/upgrade-to-ga.md
+++ b/content/en/legacy/helm-operator/how-to/upgrade-to-ga.md
@@ -5,7 +5,7 @@ title: Upgrade from beta (>=0.5.0) to stable (>=1.0.0)
 linkTitle: Upgrade to GA
 ---
 
-Due to the Flux CD project joining the CNCF Sandbox and the API
+Due to the Flux project joining the CNCF Sandbox and the API
 becoming stable, the Helm Operator has undergone changes that
 necessitate some changes to your `HelmRelease` resources.
 


### PR DESCRIPTION
Flux is just called "Flux".
https://github.com/open-gitops/documents/pull/47/files#r762415300

Signed-off-by: lloydchang <lloydchang@gmail.com>