### PR TITLE
Fix AWS KMS eksctl command

### DIFF
--- a/content/en/docs/guides/mozilla-sops.md
+++ b/content/en/docs/guides/mozilla-sops.md
@@ -291,7 +291,7 @@ eksctl create iamserviceaccount \
 --override-existing-serviceaccounts \
 --name=kustomize-controller \
 --namespace=flux-system \
---attach-policy-arn=<policyARN> \
+--attach-role-arn=<roleARN> \
 --cluster=<clusterName>
 ```
 


### PR DESCRIPTION
The body of text suggest creating a full role which is contradicted by having the example eksctl command to attach a policy. This changes to the (I believe) correct `--attach-role-arn` flag