### PR TITLE
Fix: Added space to correct code parsing

### DIFF
--- a/content/en/docs/use-cases/jenkins.md
+++ b/content/en/docs/use-cases/jenkins.md
@@ -136,7 +136,7 @@ pipeline {
             developmentTag = "${branchName}-${gitCommit}-${unixTime}"
             developmentImage = "${dockerRepoUser}/${dockerRepoProj}:${developmentTag}"
           }
-          sh "docker build -t ${developmentImage} ./"
+          sh "docker build -t ${developmentImage} ./ "
         }
       }
     }


### PR DESCRIPTION
/" is interpreted as an escaped character, so the rest was shown as part of the string.