### PR TITLE
Remove double division and cast

### DIFF
--- a/content/en/docs/use-cases/jenkins.md
+++ b/content/en/docs/use-cases/jenkins.md
@@ -132,7 +132,7 @@ pipeline {
           script {
             gitCommit = env.GIT_COMMIT.substring(0,8)
             branchName = env.BRANCH_NAME
-            unixTime = (new Date().time / 1000) as Integer
+            unixTime = (new Date().time.intdiv(1000))
             developmentTag = "${branchName}-${gitCommit}-${unixTime}"
             developmentImage = "${dockerRepoUser}/${dockerRepoProj}:${developmentTag}"
           }


### PR DESCRIPTION
I am not much of a Groovy programmer, so when I wrote this I did not realize there was another way to do integer division.

This is just dense enough groovy syntax and hard to parse for chroma to balk at it, this resolves the issue from #698 in lieu of an upstream fix for alecthomas/chroma#588