### PR TITLE
De-emphasise GitOps Toolkit somewhat

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -201,7 +201,7 @@ What we achieved up until today is only possible because of <a href="/community"
     url="https://youtube.com/playlist?list=PL9lTuCFNLaD3fI_g-NXWVxopnJ0adn65d"
     thumbnail="0v5bjysXTL8"
     title="The Power of GitOps with Flux Playlist" %}}
-  This playlist is designed to show the powerful GitOps capabilities of Flux (and the GitOps Toolkit). Videos include project overviews, reviews, technical demos, and walk-throughs of our guides.
+  This playlist is designed to show the powerful GitOps capabilities of Flux. Videos include project overviews, reviews, technical demos, and walk-throughs of our guides.
   {{% /blocks/resource %}}
 
   {{% blocks/resource
@@ -249,6 +249,7 @@ What we achieved up until today is only possible because of <a href="/community"
 
   {{% blocks/section color="white" %}}
 
+  <p id="gitops-toolkit"></p>
   {{% blocks/project title="GitOps Toolkit"
     image="/img/building-blocks.svg" image-align="left" bg-color="blue"
     button1-url="/docs/gitops-toolkit/source-watcher/"

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Flux Documentation"
 linkTitle: "Docs"
-description: "Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit."
+description: "Open and extensible continuous delivery solution for Kubernetes."
 ---
 
 Flux is a tool for keeping Kubernetes clusters in sync with sources of
@@ -14,10 +14,6 @@ components of the Kubernetes ecosystem. In version 2, Flux supports
 multi-tenancy and support for syncing an arbitrary number of Git
 repositories, among other long-requested features.
 
-Flux is constructed with the [GitOps Toolkit](components/),
-a set of composable APIs and specialized tools for building Continuous
-Delivery on top of Kubernetes.
-
 ## Who is Flux for?
 
 Flux helps
@@ -25,10 +21,6 @@ Flux helps
 - **cluster operators** who automate provision and configuration of clusters;
 - **platform engineers** who build continuous delivery for developer teams;
 - **app developers** who rely on continuous delivery to get their code live.
-
-The [GitOps Toolkit](components/) is for **platform
-engineers** who want to make their own continuous delivery system, and
-have requirements not covered by Flux.
 
 ## What can I do with Flux?
 
@@ -47,8 +39,6 @@ synced and ready, and receive webhooks to tell it when to sync.
 The `flux` command-line tool is a convenient way to bootstrap the
 system in a cluster, and to access the custom resources that make up
 the API.
-
-![overview](/img/diagrams/gitops-toolkit.png)
 
 ## Where do I start?
 
@@ -78,6 +68,22 @@ Features:
 - Seamless integration with Git providers (GitHub, GitLab, Bitbucket)
 - Interoperability with workflow providers (GitHub Actions, Tekton, Argo)
 - Interoperability with Cluster API (CAPI) providers
+
+## What is the GitOps Toolkit?
+
+Flux is constructed with the [GitOps Toolkit components](components/), which is a set of
+
+- specialized tools and Flux Controllers
+- composable APIs
+- reusable Go packages for GitOps under the [fluxcd GitHub organisation](https://github.com/fluxcd)
+
+for building Continuous Delivery on top of Kubernetes.
+
+The [GitOps Toolkit](components/) can be used individually by **platform
+engineers** who want to make their own continuous delivery system, and
+have requirements not covered by Flux.
+
+![GitOps Toolkit overview](/img/diagrams/gitops-toolkit.png)
 
 ## Community
 

--- a/content/en/docs/components/_index.md
+++ b/content/en/docs/components/_index.md
@@ -5,7 +5,7 @@ description: "Documentation of the individual GitOps Toolkit components and thei
 weight: 60
 ---
 
-Flux is constructed with the [GitOps Toolkit components](components/), which is a set of
+Flux is constructed with the GitOps Toolkit components, which is a set of
 
 - specialized tools and Flux Controllers
 - composable APIs
@@ -20,7 +20,7 @@ which can be created and updated by a cluster user, or by other
 automation tooling.
 
 You can use the toolkit to extend Flux, and to build your own systems
-for continuous delivery. The [the source-watcher
+for continuous delivery. The [source-watcher
 guide](../gitops-toolkit/source-watcher/) is a good place to start.
 
 A reference for each component and API type is linked below.

--- a/content/en/docs/components/_index.md
+++ b/content/en/docs/components/_index.md
@@ -1,12 +1,21 @@
 ---
 title: "GitOps Toolkit components"
 linkTitle: "Toolkit Components"
-description: "The GitOps Toolkit documentation."
+description: "Documentation of the individual GitOps Toolkit components and their APIs."
 weight: 60
 ---
 
-The GitOps Toolkit is the set of APIs and controllers that make up the
-runtime for Flux. The APIs comprise Kubernetes custom resources,
+Flux is constructed with the [GitOps Toolkit components](components/), which is a set of
+
+- specialized tools and Flux Controllers
+- composable APIs
+- reusable Go packages for GitOps under the [fluxcd GitHub organisation](https://github.com/fluxcd)
+
+for building Continuous Delivery on top of Kubernetes.
+
+![GitOps Toolkit overview](/img/diagrams/gitops-toolkit.png)
+
+The APIs comprise Kubernetes custom resources,
 which can be created and updated by a cluster user, or by other
 automation tooling.
 

--- a/content/en/docs/concepts.md
+++ b/content/en/docs/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Core Concepts
-description: Core Concepts of Flux and the GitOps Toolkit.
+description: Core Concepts of Flux.
 weight: 10
 ---
 

--- a/content/en/docs/concepts.md
+++ b/content/en/docs/concepts.md
@@ -58,7 +58,7 @@ The reconciliation runs every one minute by default, but this can be changed wit
 If you make any changes to the cluster using `kubectl edit/patch/delete`,
 they will be promptly reverted. You either suspend the reconciliation or push your changes to a Git repository.
 
-For more information, take a look at the [Kustomize FAQ](faq/_index.md#kustomize-questions)
+For more information, take a look at the [Kustomize FAQ](faq.md#kustomize-questions)
 and the [Kustomization CRD](components/kustomize/kustomization.md).
 
 ## Bootstrap
@@ -70,4 +70,4 @@ are created for the Flux components, then the manifests are pushed to an existin
 The bootstrap is done using the `flux` CLI or
 using our [Terraform Provider](https://github.com/fluxcd/terraform-provider-flux).
 
-For more information, take a look at [the bootstrap documentation](installation/_index.md#bootstrap).
+For more information, take a look at [the bootstrap documentation](installation.md#bootstrap).

--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -1,7 +1,7 @@
 ---
 title: "Get Started with Flux"
 linkTitle: "Get Started"
-description: "Get Started with Flux and the GitOps Toolkit."
+description: "Get Started with Flux."
 weight: 20
 ---
 

--- a/content/en/docs/guides/_index.md
+++ b/content/en/docs/guides/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "User Guides"
 linkTitle: "Guides"
-description: "Flux and the GitOps Toolkit user guides."
+description: "Flux user guides."
 weight: 40
 ---

--- a/content/en/docs/use-cases/_index.md
+++ b/content/en/docs/use-cases/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Use Cases"
 linkTitle: "Use Cases"
-description: "Flux and the GitOps Toolkit use cases."
+description: "Flux use cases."
 weight: 50
 ---


### PR DESCRIPTION
On the typical path of a Flux user, they will read "GitOps Toolkit" a lot. In this PR I try to collect GOTK information more centrally, so that the flow of a Flux user ("I want to 	understand/install Flux") is interrupted less.

Also fix link on landing page - it was broken.

Re-use phrasing from https://github.com/fluxcd/community/blob/main/style-guide.md

Fixes: #587 

cc @priyanka-ravi 