### PR TITLE
Fix bad indentation of Kustomize patch examples

### DIFF
--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -665,8 +665,8 @@ patches:
     namespace: flux-system
   patch: |-
     - op: add
-     path: /spec/template/spec/containers/0/args/-
-     value: --aws-autologin-for-ecr
+      path: /spec/template/spec/containers/0/args/-
+      value: --aws-autologin-for-ecr
 ```
 
 #### Using Native GCP GCR Auto-Login
@@ -722,6 +722,6 @@ patches:
     namespace: flux-system
   patch: |-
     - op: add
-     path: /spec/template/spec/containers/0/args/-
-     value: --azure-autologin-for-acr
+      path: /spec/template/spec/containers/0/args/-
+      value: --azure-autologin-for-acr
 ```


### PR DESCRIPTION
The examples provided are with bad indentation for the Kustomize patch, generating an reconciliation error when applied like below:

```
$ kustomize build
Error: trouble configuring builtin PatchTransformer with config: `
patch: "- op: add\n path: /spec/template/spec/containers/0/args/-\n value: --aws-autologin-for-ecr
  \  "
target:
  group: apps
  kind: Deployment
  name: image-reflector-controller
  namespace: flux-system
  version: v1
`: unable to parse SM or JSON patch from [- op: add
 path: /spec/template/spec/containers/0/args/-
 value: --aws-autologin-for-ecr]
```