### PR TITLE
Update flux-v1-migration.md

### DIFF
--- a/content/en/docs/migration/flux-v1-migration.md
+++ b/content/en/docs/migration/flux-v1-migration.md
@@ -23,8 +23,8 @@ and need help, please refer to the [support page](https://fluxcd.io/support/).
 
 ## Prerequisites
 
-You will need a Kubernetes cluster version **1.16** or newer
-and kubectl version **1.18** or newer.
+You will need a Kubernetes cluster version **1.20** or newer
+and kubectl version **1.20** or newer.
 
 ### Install Flux v2 CLI
 


### PR DESCRIPTION
`flux check --pre` returns that 1.20 is the current required version of kubernetes

Signed-off-by: Keith Petersen <krp@keithrpetersen.com>