### PR TITLE
More detailed native Azure ACR auto-login docs

### DIFF
--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -736,10 +736,10 @@ be used to give the `image-reflector-controller` pod access to the ACR. To do th
 `aad-pod-identity` on your cluster, create a managed identity that has access to the container registry (this can
 also be the Kubelet identity if it has `AcrPull` role assignment on the ACR), create an `AzureIdentity` and
 `AzureIdentityBinding` that describe the managed identity and then label the `image-reflector-controller` pods with
-the name of the `AzureIdentity` as shown in the patch above. Please take a look at this
-[guide](https://azure.github.io/aad-pod-identity/docs/) or
-[this one](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) if you want to use AKS pod-managed
-identities add-on that is in preview.
+the name of the `AzureIdentity` as shown in the patch above.
+Please take a look at [this guide](https://azure.github.io/aad-pod-identity/docs/)
+or [this one](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) if you want to use AKS
+pod-managed identities add-on that is in preview.
 {{% /alert %}}
 
 [v0.16.0 image reflector changelog]: https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0160

--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -730,13 +730,16 @@ patches:
       value: <name-of-identity>
 ```
 
-{{% alert color="info" title="AAD Pod Identity" %}}
-When using managed identity on an AKS cluster, AAD Pod Identity has to be used to give the image-automation-controller
-pod access to ACR. To do this, you have to install aad pod identity on your cluster, create a managed identity that has
-access to the container registry, create an azure identity and azure identity binding that describes the managed identity
-and then label the image-reflector-controller pods with the name of the azure identity.
-Please, take a look at this [guide](https://azure.github.io/aad-pod-identity/docs/) or 
-[this one](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) if you want to use AKS pod-managed identities add-on that is in preview.
+{{% alert color="info" title="AKS with Managed Identity" %}}
+When using managed identity on an AKS cluster, [AAD Pod Identity](https://azure.github.io/aad-pod-identity) has to
+be used to give the `image-reflector-controller` pod access to the ACR. To do this, you have to install
+`aad-pod-identity` on your cluster, create a managed identity that has access to the container registry (this can
+also be the Kubelet identity if it has `AcrPull` role assignment on the ACR), create an `AzureIdentity` and
+`AzureIdentityBinding` that describe the managed identity and then label the `image-reflector-controller` pods with
+the name of the `AzureIdentity` as shown in the patch above. Please take a look at this
+[guide](https://azure.github.io/aad-pod-identity/docs/) or
+[this one](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) if you want to use AKS pod-managed
+identities add-on that is in preview.
 {{% /alert %}}
 
 [v0.16.0 image reflector changelog]: https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0160


### PR DESCRIPTION
At first I just wanted to fix an error in the docs (`image-automation-controller` -> `image-reflector-controller`) but then I also changed some formatting (using actual Kubernetes resource names) and added a hint to simply using the Kubelet identity as opposed to creating a new one.