### PR TITLE
Add tooltip on the adopters' logos

### DIFF
--- a/hack/adopters.py
+++ b/hack/adopters.py
@@ -78,7 +78,7 @@ def write_adopter_logos_for_landing_page(data):
     for entry in data:
         if entry['logo'] not in html:
             html += """
-        <img src="{logo}" alt="{caption}">""".format(
+        <img src="{logo}" alt="{caption}" title="{caption}">""".format(
             logo=entry['logo'],
             caption=entry['name'])
 


### PR DESCRIPTION
Some logos don't reveal the name of the adopter. Add tooltip to show the
name when hovered.

![tooltip](https://user-images.githubusercontent.com/614105/155181500-f866e893-cbda-422a-9475-4b82d0f3ba82.png)


