### PR TITLE
Add a note about migration from cronjob to native authentication

### DIFF
--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -742,4 +742,9 @@ or [this one](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identi
 pod-managed identities add-on that is in preview.
 {{% /alert %}}
 
+{{% alert title="Migrating from cron-based registry credentials sync" color="warning" %}}
+If you are migrating from the [Generating Tokens for Managed Identities [short-lived]](https://fluxcd.io/docs/guides/cron-job-image-auth/#generating-tokens-for-managed-identities-short-lived) approach, `spec.secretRef` must be removed from your `ImageRepository`!
+Failing to do so will, eventually, cause the `image-reflector-controller` to use stale credentials when it tries to get images from the ACR.
+{{% /alert %}}
+
 [v0.16.0 image reflector changelog]: https://github.com/fluxcd/image-reflector-controller/blob/main/CHANGELOG.md#0160


### PR DESCRIPTION
When migrating from cron-based image registry authentication to native auto login, we ran into a problem where the image-reflector-controller got "UNAUTHORIZED: authentication required" when trying to pull images.
Failing to remove `spec.secretRef` from our `ImageRepository` was causing this issue. 

Solution was found in this Slack thread:
https://cloud-native.slack.com/archives/CLAJ40HV3/p1645436144440909?thread_ts=1644490368.977819&cid=CLAJ40HV3