### PR TITLE
fixup reference to kubeval

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -191,7 +191,7 @@ kustomize build --load-restrictor=LoadRestrictionsNone --reorder=legacy . \
 To validate changes before committing and/or merging, [a validation
 utility script is available](https://github.com/fluxcd/flux2-kustomize-helm-example/blob/main/scripts/validate.sh),
 it runs `kustomize` locally or in CI with the same set of flags as
-the controller and validates the output using `kubeval`.
+the controller and validates the output using `kubeconform`.
 {{% /alert %}}
 
 ### How do I resolve `webhook does not support dry run` errors?


### PR DESCRIPTION
We no longer refer to `kubeval` in our conformance/validation scripts. The `kubeconform` tool is maintained, performs much better according to the copy on their README, and supports (all?) of the same options as it is meant to replace `kubeval`.

* https://github.com/fluxcd/flux2-kustomize-helm-example/pull/54
* https://github.com/fluxcd/flux2-multi-tenancy/pull/64
* https://github.com/fluxcd/kustomize-controller/pull/582