### PR TITLE
Add link to Flagger docs from /docs page

### DIFF
--- a/content/en/docs/flagger.md
+++ b/content/en/docs/flagger.md
@@ -1,0 +1,6 @@
+---
+title: Flagger
+manualLink: https://docs.flagger.app
+manualLinkTarget: _blank
+weight: 150
+---

--- a/content/en/docs/security/_index.md
+++ b/content/en/docs/security/_index.md
@@ -2,6 +2,7 @@
 title: "Security Documentation"
 linkTitle: "Security"
 description: "Flux Security documentation."
+weight: 140
 ---
 
 <!-- For doc writers: Step-by-step security instructions should live on the appropriate documentation pages.


### PR DESCRIPTION
Fixes: #790
