### PR TITLE
Fix comands in ecr-credentials-sync CronJob

### DIFF
--- a/content/en/docs/guides/cron-job-image-auth.md
+++ b/content/en/docs/guides/cron-job-image-auth.md
@@ -115,14 +115,14 @@ spec:
             - mountPath: /token
               name: token
             command:
-            - /bin/bash
+            - /bin/sh
             - -ce
             - |-
               kubectl create secret docker-registry $SECRET_NAME \
                 --dry-run=client \
                 --docker-server="$ECR_REGISTRY" \
                 --docker-username=AWS \
-                --docker-password="$(</token/ecr-token)" \
+                --docker-password="$(cat /token/ecr-token)" \
                 -o yaml | kubectl apply -f -
 ```
 


### PR DESCRIPTION
`bash` is not available in docker image and `$(<` doesn't work with `sh`

Fix: #797