### PR TITLE
Remove GoFish instructions to install 'flux'

### DIFF
--- a/content/en/docs/cmd/_index.md
+++ b/content/en/docs/cmd/_index.md
@@ -19,12 +19,6 @@ With [Homebrew](https://brew.sh):
 brew install fluxcd/tap/flux
 ```
 
-With [GoFish](https://gofi.sh):
-
-```sh
-gofish install flux
-```
-
 {{% /tab %}}
 {{% tab "Linux" %}}
 
@@ -46,12 +40,6 @@ With [nix-env](https://nixos.org/manual/nix/unstable/command-ref/nix-env.html):
 nix-env -i fluxcd
 ```
 
-With [GoFish](https://gofi.sh):
-
-```sh
-gofish install flux
-```
-
 {{% /tab %}}
 {{% tab "Windows" %}}
 
@@ -59,12 +47,6 @@ With [Chocolatey](https://chocolatey.org/):
 
 ```powershell
 choco install flux
-```
-
-With [GoFish](https://gofi.sh):
-
-```sh
-gofish install flux
 ```
 
 {{% /tab %}}

--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -38,15 +38,6 @@ brew install fluxcd/tap/flux
 ```
 
 {{% /tab %}}
-{{% tab "GoFish" %}}
-
-With [GoFish](https://gofi.sh) for Windows, macOS and Linux:
-
-```sh
-gofish install flux
-```
-
-{{% /tab %}}
 {{% tab "bash" %}}
 
 With [Bash](https://www.gnu.org/software/bash/) for macOS and Linux:


### PR DESCRIPTION
It's been archived.
Fixes: #851

Signed-off-by: Daniel Holbach <daniel@weave.works>