### PR TITLE
Add note to image-update.md about namespaces

### DIFF
--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -367,6 +367,8 @@ These markers are placed inline in the target YAML, as a comment.  The "Setter" 
 which Flux can find and replace during reconciliation, when directed to do so by an `ImageUpdateAutomation` 
 like the one [above](#configure-image-updates).
 
+**Note:** Image policy specifications specified in the above format must be configured with the same namespace that the ImageUpdateAutomation controller is defined in, otherwise they will not be detected by the image automation controller.
+
 Here are some examples of using this marker in a variety of Kubernetes resources.
 
 `HelmRelease` example:


### PR DESCRIPTION
When an ImageUpdateAutomation is specified in namespace A, the image-automation controller will select imagepolicy setters which match the namespace of the ImageUpdateAutomation object

This caused me some confusion for a while - in our case we have a single `flux-system` ImageUpdateAutomation resource in our bootstrapped flux repositories, and because this wasn't explicitly mentioned at this point in the docs, I assumed it would make more sense to put the ImagePolicy and ImageRepository resources in the namespaces of their relevant deployments, rather than in the `flux-system` one, however these aren't found by the image-automation setters.

The language could be improved, but I was struggling to word the explanation.