### PR TITLE
Fix old toolkit.fluxcd.io links, move most (internal) links to be relative

### DIFF
--- a/content/en/blog/2020-12-01-december-update/index.md
+++ b/content/en/blog/2020-12-01-december-update/index.md
@@ -27,9 +27,7 @@ To get you started with setting up Flux and managing multi-tenant environments, 
 
 ## Guides for Helm users
 
-If you have been using the Helm Operator in the past, you should be able to easily upgrade to the Helm Controller (Flux v2). Check out this guide and please give us feedback - we’d love to hear from you:
-
-<https://toolkit.fluxcd.io/guides/helm-operator-migration/>
+If you have been using the Helm Operator in the past, you should be able to easily upgrade to the Helm Controller (Flux v2). Check out [this guide](/docs/migration/helm-operator-migration/) and please give us feedback - we’d love to hear from you:
 
 If you are interested in an example which describes how you can keep e.g. two clusters updated with minimal duplication, check out this repository - it uses Flux v2, Helm and Kustomize:
 

--- a/content/en/blog/2021-01-06-january-update.md
+++ b/content/en/blog/2021-01-06-january-update.md
@@ -20,7 +20,7 @@ The Flux community has set itself very ambitious goals for version 2 and
 as it's a multi-month project, we strive to inform you each month about
 what has already landed, new possibilities which are available for
 integration and where you can get involved. Read last month's update
-[here](https://fluxcd.io/blog/2020/12/december-update/).
+[here](/blog/2020/12/december-update/).
 
 Let's recap what happened in December - there have been many changes.
 
@@ -112,7 +112,7 @@ Azure DevOps users will have to specify to use libgit2 in their
 GitRepository resources.
 
 Follow [the generic git server
-guide](https://fluxcd.io/docs/installation/#generic-git-server)
+guide](/docs/installation/#generic-git-server)
 for further instructions in how to use Flux with Azure DevOps.
 
 Upcoming events
@@ -136,7 +136,7 @@ big discussions:
 If you like what you read and would like to get involved, here are a few
 good ways to do that:
 
-- Join our [upcoming dev meeting](https://fluxcd.io/community/#meetings) on Jan 14
+- Join our [upcoming dev meeting](/community/#meetings) on Jan 14
 - Talk to us in the \#flux channel on [CNCF Slack](https://slack.cncf.io/)
 - Join the [planning discussions](https://github.com/fluxcd/flux2/discussions)
 - And if you are completely new to Flux v2, take a look at our [Get Started guide](/docs/get-started/) and give us feedback

--- a/content/en/blog/2021-01-06-january-update.md
+++ b/content/en/blog/2021-01-06-january-update.md
@@ -76,7 +76,7 @@ improvements, it comes with many new features. The highlights are:
 Automated Image Updates
 -----------------------
 
-[Automated Image Updates Guide](https://toolkit.fluxcd.io/guides/image-update/) (alpha release)
+[Automated Image Updates Guide](/docs/guides/image-update/) (alpha release)
 
 Flux v2 now includes two controllers for automating image updates \--
 one of the controllers is for scanning container image repositories, and
@@ -130,7 +130,7 @@ Upcoming events
 The Flux community is growing and we are in the middle of a quite a few
 big discussions:
 
-- We have a new guide which explains core concepts in the Flux world: [https://toolkit.fluxcd.io/core-concepts/](https://toolkit.fluxcd.io/core-concepts/) - please give feedback - and thanks Somtochi!
+- We have [a new guide which explains core concepts](/docs/concepts/) in the Flux world - please give feedback - and thanks Somtochi!
 - Flux applies to upgrade to CNCF Incubation status: [https://github.com/cncf/toc/pull/567](https://github.com/cncf/toc/pull/567)
 
 If you like what you read and would like to get involved, here are a few
@@ -139,7 +139,7 @@ good ways to do that:
 - Join our [upcoming dev meeting](https://fluxcd.io/community/#meetings) on Jan 14
 - Talk to us in the \#flux channel on [CNCF Slack](https://slack.cncf.io/)
 - Join the [planning discussions](https://github.com/fluxcd/flux2/discussions)
-- And if you are completely new to Flux v2, take a look at our [Get Started guide](https://toolkit.fluxcd.io/get-started/) and give us feedback
+- And if you are completely new to Flux v2, take a look at our [Get Started guide](/docs/get-started/) and give us feedback
 - Social media: Follow [Flux on Twitter](https://twitter.com/fluxcd), join the discussion in the [Flux LinkedIn group](https://www.linkedin.com/groups/8985374/)
 
 We are looking forward to working with you.

--- a/content/en/blog/2021-02-01-february-update.md
+++ b/content/en/blog/2021-02-01-february-update.md
@@ -210,7 +210,7 @@ good ways to do that:
 - Talk to us in the \#flux channel on [CNCF Slack](https://slack.cncf.io/)
 - Join the [planning discussions](https://github.com/fluxcd/flux2/discussions)
 - And if you are completely new to Flux v2, take a look at our [Get
-  Started guide](https://toolkit.fluxcd.io/get-started/) and give us feedback
+  Started guide](/docs/get-started/) and give us feedback
 - Social media: Follow [Flux on Twitter](https://twitter.com/fluxcd), join the
   discussion in the [Flux LinkedIn group](https://www.linkedin.com/groups/8985374/).
 

--- a/content/en/blog/2021-02-01-february-update.md
+++ b/content/en/blog/2021-02-01-february-update.md
@@ -64,14 +64,14 @@ aware of what's coming next.
 ## fluxcd.io website updates
 
 In the last months' summaries we talked about our plans of revamping our
-[fluxcd.io website](https://fluxcd.io/). Originally it was mostly just
+[fluxcd.io website](/). Originally it was mostly just
 spiffy placeholder page which pointed to more Flux resources. Since then
 we landed a new design, made its focus Flux2, now we have added two pages
 which should hopefully help new users and aspiring contributors learn
 about their options getting help and joining the team
 
-- [Community \| Flux](https://fluxcd.io/community/) and
-- [SUPPORT \| Flux](https://fluxcd.io/support/)
+- [Community \| Flux](/community/) and
+- [SUPPORT \| Flux](/support/)
 
 Please let us know if there's anything missing or you'd like to help
 with the site or docs.

--- a/content/en/blog/2021-03-01-march-update/index.md
+++ b/content/en/blog/2021-03-01-march-update/index.md
@@ -23,7 +23,7 @@ The Flux community has set itself very ambitious goals for version 2 and
 as it's a multi-month project, we strive to inform you each month about
 what has already landed, new possibilities which are available for
 integration and where you can get involved. Read last month's update
-here: [February 2021 Update](https://fluxcd.io/blog/2021/02/february-2021-update/).
+here: [February 2021 Update](/blog/2021/02/february-2021-update/).
 
 Let's recap what happened in February - there have been many changes.
 
@@ -159,13 +159,12 @@ this schedule:
 - \"early\" meeting: Uneven weeks: Wed, 10:00 UTC
 - \"late\" meeting: Even weeks: Thu, 15:00 UTC
 
-Find all the information about meetings here:
-<https://fluxcd.io/community/#meetings>
+Find all [the information about meetings here](/community/#meetings).
 
 If you like what you read and would like to get involved, here are a few
 good ways to do that:
 
-- Join our [upcoming dev meetings](https://fluxcd.io/community/#meetings)
+- Join our [upcoming dev meetings](/community/#meetings)
   on March, 3rd 12:00 UTC, or March 11th, 15:00 UTC
 - Talk to us in the `#flux` channel on [CNCF Slack](https://slack.cncf.io/)
 - Join the [planning discussions](https://github.com/fluxcd/flux2/discussions)

--- a/content/en/blog/2021-03-01-march-update/index.md
+++ b/content/en/blog/2021-03-01-march-update/index.md
@@ -109,8 +109,7 @@ Capili](https://www.meetup.com/GitOps-Community/events/276539791/)
 > Flux v2.
 >
 > In this session, Leigh Capili, DX Engineer at Weaveworks, will demo
-> the Flux guide on how to Migrate from Flux v1
-> (<https://toolkit.fluxcd.io/guides/flux-v1-migration/>),
+> the [Flux guide on how to Migrate from Flux v1](/docs/migration/flux-v1-migration/),
 > including boostrapping a cluster with Flux 1 and how to move it over
 > to Flux v2.
 >
@@ -120,10 +119,9 @@ Capili](https://www.meetup.com/GitOps-Community/events/276539791/)
 >
 > Resources:
 >
-> 📍 Flux v2 Documentation: <https://toolkit.fluxcd.io/>
+> 📍 [Flux v2 Documentation](/docs/)
 >
-> 📍 Flux v2 Guide Migrate from Flux v1:
-> <https://toolkit.fluxcd.io/guides/flux-v1-migration/>
+> 📍 [Flux v2 Guide Migrate from Flux v1](/docs/migration/flux-v1-migration/)
 >
 > 📍 [Flux v2 roadmap](/roadmap/).
 
@@ -172,7 +170,7 @@ good ways to do that:
 - Talk to us in the `#flux` channel on [CNCF Slack](https://slack.cncf.io/)
 - Join the [planning discussions](https://github.com/fluxcd/flux2/discussions)
 - And if you are completely new to Flux v2, take a look at our
-  [Get Started guide](https://toolkit.fluxcd.io/get-started/) and
+  [Get Started guide](/docs/get-started/) and
   give us feedback
 - Social media: Follow [Flux on Twitter](https://twitter.com/fluxcd),
   join the discussion in the [Flux LinkedIn

--- a/content/en/blog/2021-03-08-flux-is-a-cncf-incubation-project/index.md
+++ b/content/en/blog/2021-03-08-flux-is-a-cncf-incubation-project/index.md
@@ -107,6 +107,5 @@ Check out the following upcoming events
 > 19 Apr 2021 - [Setting up Notifications, Alerts, & Webhook with Flux
 > v2 by Alison Dowdney](https://www.meetup.com/GitOps-Community/events/276582835/)
 
-Or dive straight into
-our [Get Started guide](https://toolkit.fluxcd.io/get-started/)
+Or dive straight into our [Get Started guide](/docs/get-started/)
 to get started with the next generation of Flux today.

--- a/content/en/blog/2021-03-08-flux-is-a-cncf-incubation-project/index.md
+++ b/content/en/blog/2021-03-08-flux-is-a-cncf-incubation-project/index.md
@@ -68,9 +68,8 @@ toward a GA release, at which point we'll recommend that all Flux v1
 users migrate to Flux v2.
 
 Now is the perfect time to familiarise yourself with [Flux
-v2](https://fluxcd.io) - the Get Started guide only takes a
-couple of minutes to complete. If you prefer a video, check out
-[our resources section](https://fluxcd.io/#resources).
+v2](/) - the Get Started guide only takes a couple of minutes to complete.
+If you prefer a video, check out [our resources section](/#resources).
 
 Migrating from v1 will require some work, but it will definitely be
 worth it: in this iteration you are going to get

--- a/content/en/blog/2021-03-31-april-update.md
+++ b/content/en/blog/2021-03-31-april-update.md
@@ -67,8 +67,7 @@ Hot on the heels of this was `0.11.0` and v0.1.1 of the Terraform module.
 - SOPS in the `kustomize-controller` has been updated to v3.7.0, support for the newly added age encryption format is planned. :hourglass_flowing_sand:
 - All controllers do now record the suspend status of resources in a gotk_suspend_status Prometheus gauge metric.
 
-🚀 Check out the guide on how to automate image updates to Git
-[https://toolkit.fluxcd.io/guides/image-update/](https://toolkit.fluxcd.io/guides/image-update/).
+🚀 Check out [the guide on how to automate image updates to Git](/docs/guides/image-update/).
 
 Next up we will triage `image-*` issues and mark upcoming changes for
 v1alpha2. The proposal for v1alpha2 is under discussion at [https://github.com/fluxcd/flux2/discussions/1124](https://github.com/fluxcd/flux2/discussions/1124).
@@ -232,9 +231,7 @@ good ways to do that:
   discussions](https://github.com/fluxcd/flux2/discussions)
 
 - And if you are completely new to Flux v2, take a look at our [Get
-  Started
-  guide](https://toolkit.fluxcd.io/get-started/) and
-  give us feedback
+  Started guide](/docs/get-started/) and give us feedback
 
 - Social media: Follow [Flux on
   Twitter](https://twitter.com/fluxcd), join the

--- a/content/en/blog/2021-03-31-april-update.md
+++ b/content/en/blog/2021-03-31-april-update.md
@@ -97,8 +97,7 @@ who use Flux in production.
 Here is a bit of a press round-up if you want to read more about the
 history, the move itself and what it means:
 
-- Our own announcement:
-  [https://fluxcd.io/blog/2021/03/flux-is-a-cncf-incubation-project/](https://fluxcd.io/blog/2021/03/flux-is-a-cncf-incubation-project/)
+- **[Our own announcement](/blog/2021/03/flux-is-a-cncf-incubation-project/)**
 - CNCF:
   [https://www.cncf.io/blog/2021/03/11/cncf-toc-votes-to-move-flux-from-sandbox-to-incubation/](https://www.cncf.io/blog/2021/03/11/cncf-toc-votes-to-move-flux-from-sandbox-to-incubation/)
 - CNCF On-Demand Webinar: Flux is Incubating + The Road Ahead:
@@ -220,8 +219,7 @@ cohesive and inviting, please talk to \@dholbach or \@alisondy on Slack.
 If you like what you read and would like to get involved, here are a few
 good ways to do that:
 
-- Join our [upcoming dev
-  meetings](https://fluxcd.io/community/#meetings) on
+- Join our [upcoming dev meetings](/community/#meetings) on
   2012-04-08 15:00 UTC, or 2021-04-14, 12:00 UTC
 
 - Talk to us in the \#flux channel on [CNCF

--- a/content/en/blog/2021-04-29-may-update/index.md
+++ b/content/en/blog/2021-04-29-may-update/index.md
@@ -23,7 +23,7 @@ The Flux community has set itself very ambitious goals for version 2 and
 as it's a multi-month project, we strive to inform you each month about
 what has already landed, new possibilities which are available for
 integration and where you can get involved. Read last month's update
-here: <https://fluxcd.io/blog/2021/03/april-2021-update/>.
+[here](/blog/2021/03/april-2021-update/).
 
 Let's recap what happened in April - there has been so much happening!
 
@@ -232,7 +232,7 @@ We feel very fortunate to have Alison on board!
 If you like what you read and would like to get involved, here are a few
 good ways to do that:
 
-- Join our [upcoming dev meetings](https://fluxcd.io/community/#meetings) on
+- Join our [upcoming dev meetings](/community/#meetings) on
   2021-05-12 12:00 UTC, or 2021-05-20 15:00 UTC
 - Talk to us in the \#flux channel on [CNCF Slack](https://slack.cncf.io/)
 - Join the [planning discussions](https://github.com/fluxcd/flux2/discussions)

--- a/content/en/blog/2021-05-31-june-update/index.md
+++ b/content/en/blog/2021-05-31-june-update/index.md
@@ -162,14 +162,14 @@ and [links to recordings](/resources) of past talks.
 ### Reviewing Flux Governance
 
 More than half a year ago we established our [Flux Governance
-document](https://fluxcd.io/governance/). The idea behind
+document](/governance/). The idea behind
 it was to formalise our values around community, the roles and
 responsibilities and processes; many of which had been transparent and
 with our full integrity, but still quite ad-hoc up until that point.
 
 For us it's time to review this together with our
-[Community](https://fluxcd.io/community/) and
-[Contributors docs](https://fluxcd.io/docs/contributing/).
+[Community](/community/) and
+[Contributors docs](/docs/contributing/).
 So we are turning to you for feedback: [please let us know what you
 think](https://github.com/fluxcd/flux2/discussions/1457).
 What was your experience up until now? Do you feel things are clear

--- a/content/en/blog/2021-07-02-july-update/index.md
+++ b/content/en/blog/2021-07-02-july-update/index.md
@@ -14,7 +14,7 @@ As the Flux family of projects and its communities are growing, we
 strive to inform you each month about what has already landed, new
 possibilities which are available for integration and where you can get
 involved. Read [last month's update
-here](https://fluxcd.io/blog/2021/05/june-2021-update/).
+here](/blog/2021/05/june-2021-update/).
 
 Let's recap what happened in June - there has been so much happening!
 
@@ -188,7 +188,7 @@ and chat with our engineers.
 ### The Bug Scrub
 
 Kingdon Barrett organised our first ever [Bug
-Scrub](https://fluxcd.io/blog/2021/06/flux-bug-scrub-announce/).
+Scrub](/blog/2021/06/flux-bug-scrub-announce/).
 To quote from the announcement:
 
 > For us, a great way to get started, is to learn more about Flux
@@ -254,7 +254,7 @@ of development, providing a unique developer experience with Flux.
 Our web and docs team has been busy as well.
 
 🤹 First of all we would like to congratulate everyone who added
-themselves to the [Flux Adopters page](https://fluxcd.io/adopters/). It's
+themselves to the [Flux Adopters page](/adopters/). It's
 beautiful for all of us who work on the Flux to see how our projects are
 used in the wild.
 
@@ -266,7 +266,7 @@ hard to update and some of our users got confused about which docs they
 were looking at. If you have any feedback about this, let us know.
 
 🔋 We also just added a [Flux Integrations
-page](https://fluxcd.io/integrations/). If your extension
+page](/integrations/). If your extension
 or integration is not listed yet, please add yourself. We will make this
 page shine more in the future - we are also happy to work on joint blog
 posts, etc. Just come and talk to us!
@@ -287,14 +287,14 @@ If you like what you read and would like to get involved, here are a few
 good ways to do that:
 
 - Join our [upcoming dev
-   meetings](https://fluxcd.io/community/#meetings) on
+   meetings](/community/#meetings) on
    2021-07-01 15:00 UTC, or 2021-07-07, 12:00 UTC.
 - Talk to us in the \#flux channel on [CNCF
    Slack](https://slack.cncf.io/)
 - Join the [planning
    discussions](https://github.com/fluxcd/flux2/discussions)
 - And if you are completely new to Flux v2, take a look at our [Get
-   Started guide](https://fluxcd.io/docs/get-started/)
+   Started guide](/docs/get-started/)
    and give us feedback
 - Social media: Follow [Flux on
    Twitter](https://twitter.com/fluxcd), join the

--- a/content/en/blog/2021-08-02-august-update/index.md
+++ b/content/en/blog/2021-08-02-august-update/index.md
@@ -130,7 +130,7 @@ to Scott Rigby on Slack.
 In last month's update we discussed how Flux's APIs are now stable. To
 clarify what this means for the Flux project as a whole, we added the
 following section to [our migration
-timetable](https://fluxcd.io/docs/migration/timetable/):
+timetable](/docs/migration/timetable/):
 
 - Flux 1: Superseded
   - All existing projects encouraged to migrate to Flux 2, and

--- a/content/en/blog/2021-08-30-september-update/index.md
+++ b/content/en/blog/2021-08-30-september-update/index.md
@@ -161,7 +161,7 @@ commitment is minimal!
 
 Find our calendar on the Flux website where, thanks to some updates,
 finding the [date and time of the next Bug Scrub
-meeting](https://fluxcd.io/#calendar) is now more
+meeting](/#calendar) is now more
 accessible than ever before.
 
 The Zoom link is broadcast via Slack a few minutes before the

--- a/content/en/blog/2021-10-01-october-update.md
+++ b/content/en/blog/2021-10-01-october-update.md
@@ -218,8 +218,7 @@ work! There will always be plenty of bugs to scrub for the foreseeable
 future.
 
 This week, and every other week, find Bug Scrub with a link to the Zoom
-invite beneath the fold at
-[https://fluxcd.io/\#calendar](/#calendar)
+invite [beneath the fold](/#calendar)
 alongside other scheduled Flux developer team events.
 
 ### One more thing
@@ -234,12 +233,12 @@ teams moving to GitOps.
 > you manage Kubernetes applications --- Helm Charts helps you define,
 > install, and upgrade even the most complex Kubernetes application.
 >
-> 🔹The GitOps Toolkit - <https://fluxcd.io/docs/components>
+> 🔹[The GitOps Toolkit](/docs/components)
 > is the set of APIs and controllers that make up the runtime for Flux.
 > The APIs comprise Kubernetes custom resources, which can be created
 > and updated by a cluster user, or by other automation tooling.
 >
-> 🔹The Helm Controller - <https://fluxcd.io/docs/components/helm/>
+> 🔹[The Helm Controller](/docs/components/helm/)
 > built on Kubernetes controller runtime and is part of the GitOps
 > Toolkit -- allows one to declaratively manage Helm chart releases with
 > Kubernetes manifests.

--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -469,4 +469,4 @@ to help you migrate to Flux v2:
 
 ### Where can I find information on how long versions are supported and how often to expect releases?
 
-Releases are as needed for now and a release page with the schedule will be created when Flux reaches general availability status ([Flux roadmap can be found here](https://fluxcd.io/roadmap/)). We understand the importance of having a release schedule and are aware that such a schedule will support the users' ability to plan for an upgrade in advance. For now you can expect the current release cadence of at least once per month to continue.
+Releases are as needed for now and a release page with the schedule will be created when Flux reaches general availability status ([Flux roadmap can be found here](/roadmap/)). We understand the importance of having a release schedule and are aware that such a schedule will support the users' ability to plan for an upgrade in advance. For now you can expect the current release cadence of at least once per month to continue.

--- a/content/en/docs/flux-e2e.md
+++ b/content/en/docs/flux-e2e.md
@@ -114,7 +114,7 @@ changes to a given Git repository. The behavior of the automation process is def
 
 That resource defines the way that automated commits are created and pushed.  The `ImagePolicy` is another custom resource that determines what image tags go
 where. `ImagePolicy` can be defined to select the latest image from images within a SemVer range, or more flexible RegEx filters with alphabetical or
-numerical sorting to select the "latest" image. Image tags can also be [filtered with FilterTags](https://fluxcd.io/docs/components/image/imagepolicies/#filtertags)
+numerical sorting to select the "latest" image. Image tags can also be [filtered with FilterTags](/docs/components/image/imagepolicies/#filtertags)
 before they are considered as candidate images by the policy rule.
 
 The updates are governed by marking fields to be updated in each YAML file. For each field marked, the automation process checks the image policy named, and
@@ -564,35 +564,35 @@ The health checking feature is called [Health Assessment][] in the Flux Kustomiz
 [Git Commit Status Provider Notifications]: #git-commit-status-provider-notifications
 [Waiting and Health Assessment for Flux Kustomization]: #waiting-and-health-assessment-for-flux-kustomization
 
-[GitOps toolkit]: https://fluxcd.io/docs/components/
-[Security]: https://fluxcd.io/docs/security/
-[Contributing: Acceptance Policy]: https://fluxcd.io/docs/contributing/flux/#acceptance-policy
-[Source controller]: https://fluxcd.io/docs/components/source/
-[Kustomize controller]: https://fluxcd.io/docs/components/kustomize/
-[Helm controller]: https://fluxcd.io/docs/components/helm/
-[Notification controller]: https://fluxcd.io/docs/components/notification/
-[Image reflector and automation controllers]: https://fluxcd.io/docs/components/image/
+[GitOps toolkit]: /docs/components/
+[Security]: /docs/security/
+[Contributing: Acceptance Policy]: /docs/contributing/flux/#acceptance-policy
+[Source controller]: /docs/components/source/
+[Kustomize controller]: /docs/components/kustomize/
+[Helm controller]: /docs/components/helm/
+[Notification controller]: /docs/components/notification/
+[Image reflector and automation controllers]: /docs/components/image/
 [Helm Chart Hooks]: https://helm.sh/docs/topics/charts_hooks/
 [Post Rendering]: https://helm.sh/docs/topics/advanced/#post-rendering
-[image automation guide]: https://fluxcd.io/docs/guides/image-update/#configure-image-update-for-custom-resources
-[Core Concepts]: https://fluxcd.io/docs/concepts/
-[Get Started with Flux]: https://fluxcd.io/docs/get-started/
-[GitRepository Custom Resource]: https://fluxcd.io/docs/components/source/gitrepositories/
-[BucketSpec Custom Resource]: https://fluxcd.io/docs/components/source/buckets/
-[HelmRepository Custom Resource]: https://fluxcd.io/docs/components/source/helmrepositories/
-[HelmChart Custom Resource]: https://fluxcd.io/docs/components/source/helmcharts/
-[Mozilla SOPS Guide]: https://fluxcd.io/docs/guides/mozilla-sops/
-[Kustomize Build Flags]: https://fluxcd.io/docs/faq/#what-is-the-behavior-of-kustomize-used-by-flux
+[image automation guide]: /docs/guides/image-update/#configure-image-update-for-custom-resources
+[Core Concepts]: /docs/concepts/
+[Get Started with Flux]: /docs/get-started/
+[GitRepository Custom Resource]: /docs/components/source/gitrepositories/
+[BucketSpec Custom Resource]: /docs/components/source/buckets/
+[HelmRepository Custom Resource]: /docs/components/source/helmrepositories/
+[HelmChart Custom Resource]: /docs/components/source/helmcharts/
+[Mozilla SOPS Guide]: /docs/guides/mozilla-sops/
+[Kustomize Build Flags]: /docs/faq/#what-is-the-behavior-of-kustomize-used-by-flux
 [server-side apply and update]: https://kubernetes.io/docs/reference/using-api/server-side-apply/
 [field management]: https://kubernetes.io/docs/reference/using-api/server-side-apply/#field-management
-[HelmRelease API]: https://fluxcd.io/docs/components/helm/api/
-[HelmRelease Guide]: https://fluxcd.io/docs/guides/helmreleases/
-[Helm Use Case]: https://fluxcd.io/docs/use-cases/helm/
-[HelmRepository API]: https://fluxcd.io/docs/components/source/helmrepositories/
-[HelmChart API]: https://fluxcd.io/docs/components/source/helmcharts/
-[HelmChartTemplate.spec.reconcileStrategy]: https://fluxcd.io/docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate
-[Setup Notifications]: https://fluxcd.io/docs/guides/notifications/
-[Alert API]: https://fluxcd.io/docs/components/notification/alert/
-[Event API]: https://fluxcd.io/docs/components/notification/event/
-[Setup Git Commit Status Notications]: https://fluxcd.io/docs/guides/notifications/#git-commit-status
-[Health Assessment]: https://fluxcd.io/docs/components/kustomize/kustomization/#health-assessment
+[HelmRelease API]: /docs/components/helm/api/
+[HelmRelease Guide]: /docs/guides/helmreleases/
+[Helm Use Case]: /docs/use-cases/helm/
+[HelmRepository API]: /docs/components/source/helmrepositories/
+[HelmChart API]: /docs/components/source/helmcharts/
+[HelmChartTemplate.spec.reconcileStrategy]: /docs/components/helm/api/#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate
+[Setup Notifications]: /docs/guides/notifications/
+[Alert API]: /docs/components/notification/alert/
+[Event API]: /docs/components/notification/event/
+[Setup Git Commit Status Notications]: /docs/guides/notifications/#git-commit-status
+[Health Assessment]: /docs/components/kustomize/kustomization/#health-assessment

--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -741,7 +741,7 @@ pod-managed identities add-on that is in preview.
 {{% /alert %}}
 
 {{% alert title="Migrating from cron-based registry credentials sync" color="warning" %}}
-If you are migrating from the [Generating Tokens for Managed Identities [short-lived]](https://fluxcd.io/docs/guides/cron-job-image-auth/#generating-tokens-for-managed-identities-short-lived) approach, `spec.secretRef` must be removed from your `ImageRepository`!
+If you are migrating from the [Generating Tokens for Managed Identities [short-lived]](/docs/guides/cron-job-image-auth/#generating-tokens-for-managed-identities-short-lived) approach, `spec.secretRef` must be removed from your `ImageRepository`!
 Failing to do so will, eventually, cause the `image-reflector-controller` to use stale credentials when it tries to get images from the ACR.
 {{% /alert %}}
 

--- a/content/en/docs/guides/monitoring.md
+++ b/content/en/docs/guides/monitoring.md
@@ -96,7 +96,7 @@ If you wish to use your own Prometheus and Grafana instances, then you can impor
 
 ![Annotations Dashboard](/img/grafana-annotation.png)
 
-If you wish to overlap [flux notifications](https://fluxcd.io/docs/components/notification/provider/#grafana) on dashboards you can do it by enabling the grafana annotations alert provider, the desired alerts and the annotation on the dashboard like shown below:
+If you wish to overlap [flux notifications](/docs/components/notification/provider/#grafana) on dashboards you can do it by enabling the grafana annotations alert provider, the desired alerts and the annotation on the dashboard like shown below:
 
 ![Annotations configuration](/img/grafana-annotations-config.png)
 

--- a/content/en/docs/migration/flux-v1-migration.md
+++ b/content/en/docs/migration/flux-v1-migration.md
@@ -18,7 +18,7 @@ accounting for the fact that it's a system with a substantially different
 design.
 This may at times mean that you have to make adjustments to the way your
 current cluster configuration is structured. If you are in this situation
-and need help, please refer to the [support page](https://fluxcd.io/support/).
+and need help, please refer to the [support page](/support/).
 {{% /alert %}}
 
 ## Prerequisites

--- a/content/en/docs/migration/helm-operator-migration.md
+++ b/content/en/docs/migration/helm-operator-migration.md
@@ -288,7 +288,7 @@ spec:
   # The Git reference to checkout and monitor for changes
   # (defaults to master)
   # For all available options, see:
-  # https://toolkit.fluxcd.io/components/source/api/#source.toolkit.fluxcd.io/v1beta2.GitRepositoryRef
+  # https://fluxcd.io/docs/components/source/api/#source.toolkit.fluxcd.io/v1beta2.GitRepositoryRef
   ref:
     branch: master
 ```

--- a/content/en/docs/use-cases/jenkins.md
+++ b/content/en/docs/use-cases/jenkins.md
@@ -319,4 +319,4 @@ Update deployments via Flux's [ImagePolicy] CRD, and the Image Update Automation
 [Kubernetes examples for Buildkit]: https://github.com/moby/buildkit/tree/master/examples/kubernetes
 [Buildkit CLI for Kubectl]: https://github.com/vmware-tanzu/buildkit-cli-for-kubectl
 [KubeCon/CloudNativeCon EU 2021]: https://www.youtube.com/watch?v=vTh6jkW_xtI
-[ImagePolicy]: https://fluxcd.io/docs/guides/sortable-image-tags/#using-in-an-imagepolicy-object
+[ImagePolicy]: /docs/guides/sortable-image-tags/#using-in-an-imagepolicy-object

--- a/content/en/legacy/flux/faq.md
+++ b/content/en/legacy/flux/faq.md
@@ -6,7 +6,7 @@ weight: 80
 
 ## Migrate to Flux v2
 
-[Flux v1 is in maintenance](https://github.com/fluxcd/flux/issues/3320) on the road to becoming formally superseded by Flux v2. Flux users are all encouraged to [migrate to Flux v2](https://toolkit.fluxcd.io/guides/flux-v1-migration/) as early as possible.
+[Flux v1 is in maintenance](https://github.com/fluxcd/flux/issues/3320) on the road to becoming formally superseded by Flux v2. Flux users are all encouraged to [migrate to Flux v2](/docs/migration/flux-v1-migration/) as early as possible.
 
 ### Why should I upgrade
 

--- a/content/en/legacy/helm-operator/helmrelease-guide/automation.md
+++ b/content/en/legacy/helm-operator/helmrelease-guide/automation.md
@@ -9,7 +9,7 @@ misconceptions about (non-existent) automation features of the Helm Operator.
 
 ## Image updates
 
-Because the Helm Operator is a [Flux umbrella project](https://fluxcd.io),
+Because the Helm Operator is a [Flux umbrella project](/),
 occasionally people assume it is capable of updating image references in
 the `HelmRelease` and/or associated charts. This feature is however baked
 in to [Flux](https://github.com/fluxcd/flux), and not the Helm Operator


### PR DESCRIPTION
Fix old toolkit.fluxcd.io links, move most (internal) links to be relative