### PR TITLE
Mention Artifact Registry in image update docs

### DIFF
--- a/content/en/docs/guides/image-update.md
+++ b/content/en/docs/guides/image-update.md
@@ -699,6 +699,11 @@ patchesStrategicMerge:
       iam.gke.io/gcp-service-account: <gcp-service-account-name>@<PROJECT_ID>.iam.gserviceaccount.com
 ```
 
+The Artifact Registry service uses the permission `artifactregistry.repositories.downloadArtifacts` that is
+located under the Artifact Registry Reader role. If you are using Google Container Registry service, the needed
+permission is instead `storage.objects.list` which can be bound as part of the Container Registry Service Agent
+role, (or it can be bound separately in your own created role for the least required permission.)
+
 Take a look at [this guide](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for more
 information about setting up GKE Workload Identity.
 


### PR DESCRIPTION
We support both GCR (legacy) and Google Artifact Registry, the newer alternative

https://cloud.google.com/blog/products/application-development/understanding-artifact-registry-vs-container-registry

Should we include this link in the docs as well, I think it is not needed but maybe could be helpful as a reference too.