### PR TITLE
Update bootstrap docs

### DIFF
--- a/content/en/docs/cheatsheets/bootstrap.md
+++ b/content/en/docs/cheatsheets/bootstrap.md
@@ -357,8 +357,8 @@ patches:
 
 ### Multi-tenancy lockdown
 
-Lock down Flux on a multi-tenant cluster by disabling cross-namespace references
-and setting a default service account:
+Lock down Flux on a multi-tenant cluster by disabling cross-namespace references and Kustomize remote bases, and
+by setting a default service account:
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -374,6 +374,13 @@ patches:
     target:
       kind: Deployment
       name: "(kustomize-controller|helm-controller|notification-controller|image-reflector-controller|image-automation-controller)"
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --no-remote-bases=true
+    target:
+      kind: Deployment
+      name: "kustomize-controller"
   - patch: |
       - op: add
         path: /spec/template/spec/containers/0/args/-

--- a/content/en/docs/cheatsheets/bootstrap.md
+++ b/content/en/docs/cheatsheets/bootstrap.md
@@ -193,6 +193,33 @@ patches:
       name: "(kustomize-controller|helm-controller|source-controller)"
 ```
 
+### Enable Helm repositories caching
+
+For large Helm repository index files, you can enable
+caching to reduce the memory footprint of source-controller:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gotk-components.yaml
+  - gotk-sync.yaml
+patches:
+  - patch: |
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --helm-cache-max-size=10
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --helm-cache-ttl=60m
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --helm-cache-purge-interval=5m
+    target:
+      kind: Deployment
+      name: source-controller
+```
+
 ### Using HTTP/S proxy for egress traffic
 
 If your cluster must use an HTTP proxy to reach GitHub or other external services,

--- a/content/en/docs/cheatsheets/bootstrap.md
+++ b/content/en/docs/cheatsheets/bootstrap.md
@@ -220,6 +220,11 @@ patches:
       name: source-controller
 ```
 
+
+When `helm-cache-max-size` is reached, an error is logged and the index is instead
+read from file. Cache hits are exposed via the `gotk_cache_events_total` Prometheus
+metrics. Use this data to fine-tune the configuration flags.
+
 ### Using HTTP/S proxy for egress traffic
 
 If your cluster must use an HTTP proxy to reach GitHub or other external services,

--- a/content/en/docs/installation.md
+++ b/content/en/docs/installation.md
@@ -543,6 +543,13 @@ patches:
       name: "(kustomize-controller|helm-controller|notification-controller|image-reflector-controller|image-automation-controller)"
   - patch: |
       - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --no-remote-bases=true
+    target:
+      kind: Deployment
+      name: "kustomize-controller"
+  - patch: |
+      - op: add
         path: /spec/template/spec/containers/0/args/0
         value: --default-service-account=default
     target:
@@ -560,6 +567,7 @@ patches:
 With the above configuration, Flux will:
 
 - Deny cross-namespace access to Flux custom resources, thus ensuring that a tenant can't use another tenant's sources or subscribe to their events.
+- Deny accesses to Kustomize remote bases, thus ensuring all resources refer to local files, meaning only the Flux Sources can affect the cluster-state.
 - All `Kustomizations` and `HelmReleases` which don't have `spec.serviceAccountName` specified, will use the `default` account from the tenant's namespace.
   Tenants have to specify a service account in their Flux resources to be able to deploy workloads in their namespaces as the `default` account has no permissions.
 - The flux-system `Kustomization` is set to reconcile under a service account with cluster-admin role,


### PR DESCRIPTION
Changes:
- Add Helm repository index caching to bootstrap cheatsheet
- Disable Kustomize remote bases on multi-tenant clusters