### PR TITLE
Revert "Update docsy to latest"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 BLOCK_STDOUT_CMD           := python -c "import os,sys,fcntl; \
                                            flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); \
                                            fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);"
-DOCSY_COMMIT 			   ?= f4d2ff87b17dfeb4c0282c49d35451d1ae362028
+DOCSY_COMMIT 			   ?= 868b75107c53196f25c6e57a3c704a556ef1f56e
 DOCSY_COMMIT_FOLDER        := docsy-$(DOCSY_COMMIT)
 DOCSY_TARGET               := themes/$(DOCSY_COMMIT_FOLDER)
 BOOTSTRAP_SEMVER           ?= 4.6.1

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -7,21 +7,22 @@
 {{ $calendar := resources.Get "js/calendar.js" | js.Build "calendar.js" }}
 <script type="text/javascript" src="{{ $calendar.RelPermalink }}" defer></script>
 
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script type="text/javascript">
 
-docsearch({
-        container: '#docsearch',
-        apiKey: 'd466984187cbf406354da362d45b8e3f',
-        appId: 'Z41T3FAXIU',
+function docsearchInit(inputSelector) {
+    return docsearch({
+        apiKey: '45f9f14d53600b0a2cafa46a26ee10f4',
         indexName: 'fluxcd',
+        inputSelector: inputSelector,
         {{ if in .Permalink "/legacy" }}
         algoliaOptions: { 'facetFilters': ["tags:legacy"] },
         {{ else }}
         algoliaOptions: { 'facetFilters': ["tags:current"] },
         {{ end }}
         debug: false // Set debug to true if you want to inspect the dropdown
-});
+    });
+}
 
+docsearchInit('.td-search-input');
 </script>
 {{ end }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -3,6 +3,6 @@
 {{ end }}
 
 {{ with .Site.Params.algolia_docsearch }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 {{ end }}
 

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -4,7 +4,7 @@
 {{ $gh_url := ($.Param "github_url") -}}
 {{ $gh_subdir := ($.Param "github_subdir") -}}
 {{ $gh_project_repo := ($.Param "github_project_repo") -}}
-{{ $gh_branch := (default "main" ($.Param "github_branch")) -}}
+{{ $gh_branch := (default "master" ($.Param "github_branch")) -}}
 {{ $importedDoc := $.Param "importedDoc" | default "false" }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ if $gh_url -}}


### PR DESCRIPTION
Reverts fluxcd/website#929

Unfortunately the search for tag `legacy` vs `current` does not work.

This is likely a mistake in how our crawler config was transitioned by the Algolia team. I'll reach out and ask if they can help us fix it.

`algoliaOptions` also needs to be changed to `searchParameters` in the new API.