### PR TITLE
Clarify that Workload Identity isn't compulsory

### DIFF
--- a/content/en/docs/use-cases/gcp-source-repository.md
+++ b/content/en/docs/use-cases/gcp-source-repository.md
@@ -68,7 +68,7 @@ See the [Mozilla SOPS AWS Guide](../guides/mozilla-sops.md#google-cloud) for fur
 
 ### Image Updates with Google Container Registry
 
-You will need to create an GCR registry and an IAM service account that has access to GCR.
+You will need to create an GCR registry. Most new GKE cluster by default have access to Google Container Registry in the same project. But if you have enabled Workload Identity on your cluster, you would need to create an IAM service account that has access to GCR.
 
 You may need to update your Flux install to include additional components:
 

--- a/content/en/legacy/flux/guides/use-gke-workload-identity.md
+++ b/content/en/legacy/flux/guides/use-gke-workload-identity.md
@@ -46,7 +46,7 @@ metadata:
   name: flux
   namespace: flux
   annotations:
-    iam.gke.io/gcp-service-account=flux-gcp@total-mayhem-123456.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: flux-gcp@total-mayhem-123456.iam.gserviceaccount.com
 ```
 
 Alternatively, if you use the Helm chart to install Flux, you can set the annotations during installation:


### PR DESCRIPTION
This pr makes it clear that workload identity isn't always need for GCR access.
Fixes: #966 

Signed-off-by: Somtochi Onyekwere <somtochionyekwere@gmail.com>