### PR TITLE
helm gh actions guide: Exclude events related to dependencies check

### DIFF
--- a/content/en/docs/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/docs/use-cases/gh-actions-helm-promotion.md
@@ -190,6 +190,7 @@ spec:
   exclusionList:
     - ".*upgrade.*has.*started"
     - ".*is.*not.*ready"
+    - "^Dependencies.*"
 ```
 
 **Note** that you should adapt the above definitions to match your GitHub repository address.


### PR DESCRIPTION
Avoid promotion for "Dependencies do not meet ready condition" events. 