### PR TITLE
Add troubleshooting note for k3s HelmChart

### DIFF
--- a/content/en/docs/cheatsheets/troubleshooting.md
+++ b/content/en/docs/cheatsheets/troubleshooting.md
@@ -52,6 +52,12 @@ kubectl get helmreleases.helm.toolkit.fluxcd.io -A
 kubectl get helmcharts.source.toolkit.fluxcd.io -A
 ```
 
+{{% alert color="warning" title="HelmCharts and HelmReleases CRDs conflict with other Helm controllers" %}}
+When a `HelmRelease` exhibits the issue `HelmChart 'podinfo/podinfo-podinfo' is not ready`, a common issue on k3s clusters or other environments that bundle a different Helm controller is caused by a conflict between these CRDs when they are used without fully qualifying.
+
+For example: `kubectl get helmcharts` can access the wrong CRD and users may be fooled into thinking that a `HelmChart` resource was not created successfully. To avoid this issue, use the alternative `flux get source chart` or fully qualify when using `kubectl get` as shown above.
+{{% /alert %}}
+
 Looking for controller errors:
 
 ```cli


### PR DESCRIPTION
Follow-up to cover common likely issue noticed while attempting to debug a red-herring issue uncovered in:

* fluxcd/source-controller#831

When users have installed on a k3s cluster, sometimes they don't ask for Helm controller but k3s still installs these CRDs:

```
addons.k3s.cattle.io                             2022-07-11T18:18:17Z
helmchartconfigs.helm.cattle.io                  2022-07-11T18:18:17Z
helmcharts.helm.cattle.io                        2022-07-11T18:18:17Z
```

This seems like the best place in our docs to highlight that `helmcharts` CRD is known to sometimes conflict with other CRDs called `helmcharts` – I suspect Rancher will be unreceptive to force their users to opt into these CRDs and adjust every doc that expects them to come pre-installed on k3s, so a mention in our docs would be worthwhile.

(Follow up on:
https://github.com/fluxcd/source-controller/issues/831#issuecomment-1183471528)