### PR TITLE
Mention Cyclonus for NetworkPolicy validation

### DIFF
--- a/content/en/docs/security/best-practices.md
+++ b/content/en/docs/security/best-practices.md
@@ -261,7 +261,7 @@ The recommendations below are based on Flux's latest version.
     <summary>Audit Procedure</summary>
 
     - Check whether you adhere to [Kubernetes Network Isolation Guidelines](https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation)
-    - Create a [Network Policy](https://fluxcd.io/docs/flux-e2e/#fluxs-default-configuration-for-networkpolicy) and confirm it is being enforced by the CNI.
+    - Confirm that the [Network Policy](https://fluxcd.io/docs/flux-e2e/#fluxs-default-configuration-for-networkpolicy) objects created by Flux are being enforced by the CNI. Alternatively, run a tool such as [Cyclonus](https://github.com/mattfenwick/cyclonus) or [Sonobuoy](https://github.com/vmware-tanzu/sonobuoy) to validate NetworkPolicy enforcement by the CNI plugin on your cluster.
   </details>
 
 ## Additional Best Practices for Tenant Dedicated Cluster Multi-tenancy


### PR DESCRIPTION
It's not easy to validate a CNI plugin's implementation of
NetworkPolicies and cyclonus is used by the Kubernetes folks:

https://kubernetes.io/blog/2021/04/20/defining-networkpolicy-conformance-cni-providers/
