### PR TITLE
Add missing `apiVersion` fields to examples in the Repository Structure page

### DIFF
--- a/content/en/flux/guides/repository-structure.md
+++ b/content/en/flux/guides/repository-structure.md
@@ -155,6 +155,7 @@ App repository plain Kubernetes manifests example:
 Delivery example (stored in config repo):
 
 ```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: app
@@ -163,6 +164,7 @@ spec:
   ref:
     semver: "1.x"
 ---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: app
@@ -193,6 +195,7 @@ App repository Kustomize overlays example:
 Delivery example (stored in config repo):
 
 ```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: app
@@ -201,6 +204,7 @@ spec:
   ref:
     branch: main
 ---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: app
@@ -224,12 +228,14 @@ App repository Helm chart example:
 Delivery example (stored in config repo):
 
 ```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: apps
 spec:
   url: https://<host>/<org>/charts
 ---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: app


### PR DESCRIPTION
Currently, the examples in the [Ways of structuring your repositories](https://fluxcd.io/docs/guides/repository-structure/) section are broken. 
The Kubernetes manifests are missing an `apiVersion` property which means they'll fail when applying.
This PR adds the missing properties to every example on that page.