### PR TITLE
Add SOCKS5 ssh proxy for git docs

### DIFF
--- a/content/en/docs/cheatsheets/bootstrap.md
+++ b/content/en/docs/cheatsheets/bootstrap.md
@@ -258,6 +258,50 @@ patches:
       labelSelector: app.kubernetes.io/part-of=flux
 ```
 
+### Git repository access via SOCKS5 ssh proxy
+
+If your cluster has Internet restrictions, requiring egress traffic to go
+through a proxy, you must use a SOCKS5 ssh proxy to be able to reach Github
+(or other external Git servers) via SSH.
+
+To configure a SOCKS5 proxy set the environment variable `ALL_PROXY` to allow
+both source-controller and image-automation-controller to connect through the
+proxy.
+
+```
+ALL_PROXY=socks5://<proxy-address>:<port>
+```
+
+The following is an example of patching the Flux setup kustomization to add the
+`ALL_PROXY` environment variable in source-controller and
+image-automation-controller:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gotk-components.yaml
+  - gotk-sync.yaml
+patches:
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: all
+      spec:
+        template:
+          spec:
+            containers:
+              - name: manager
+                env:
+                  - name: "ALL_PROXY"
+                    value: "socks5://proxy.example.com:1080"
+    target:
+      kind: Deployment
+      labelSelector: app.kubernetes.io/part-of=flux
+      name: "(source-controller|image-automation-controller)"
+```
+
 ### Test release candidates
 
 To test release candidates, you can patch the container image tags:


### PR DESCRIPTION
Tested SOCKS5 support using two separate server implementations:
- https://github.com/ring04h/s5.go
- https://github.com/MisterDaneel/pysoxy
