### PR TITLE
doc: missing parameter in example

### DIFF
--- a/content/en/docs/cheatsheets/oci-artifacts.md
+++ b/content/en/docs/cheatsheets/oci-artifacts.md
@@ -75,6 +75,7 @@ metadata:
 spec:
   interval: 10m
   targetNamespace: default
+  prune: true
   sourceRef:
     kind: OCIRepository
     name: podinfo


### PR DESCRIPTION
Missing `spec.prune` causes example to fail to reconcile:

```
Kustomization reconciliation failed: Kustomization/oci/podinfo dry-run failed, reason: Invalid, error: Kustomization.kustomize.toolkit.fluxcd.io "podinfo" is invalid: spec.prune: Required value
```

Signed-off-by: David Harris <david.harris@weave.works>