### PR TITLE
Remove @alisondy (inactive)

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -4,7 +4,6 @@ https://cloud-native.slack.com in #flux (https://cloud-native.slack.com/messages
 
 In alphabetical order:
 
-Alison Dowdney, Independent <alison@alisondowdney.com> (github: @alisondy, slack: alisondy)
 Daniel Holbach, Weaveworks <daniel@weave.works> (github: @dholbach, slack: dholbach)
 Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
 Scott Rigby, Weaveworks <scott@weave.works> (github: @scottrigby, slack: scottrigby)


### PR DESCRIPTION
Per discussion in slack, @alisondy is inactive.

(Is this the correct way to remove an inactive maintainer? I went through some history and didn't find any prior instances where we had removed someone. Way back in Flux v1 history, I found that we had a sort of "Emeritus" or retired maintainer status. Are we still doing that?)

I know we are parsing these files now, so I did not want to mess with the structure at all in case it would cause problems.

Linked with:

* https://github.com/fluxcd/community/pull/232