### PR TITLE
Add detail about Kustomize controller timeout

### DIFF
--- a/content/en/flux/flux-e2e.md
+++ b/content/en/flux/flux-e2e.md
@@ -403,10 +403,12 @@ garbage-collection and resource health assessment.  It also allows the Kubernete
 controllers can set field values within the same resource without interfering with each other.
 
 The server-side apply operation is synchronous rather than asynchronous. If any resources fail to become ready before a specified timeout, the controller can
-abort the entire transaction.
+abort the entire transaction. The timeout value is used in three separate functions, such that any or all of them can take up to `spec.timeout` seconds
+before being cancelled or timing out. So the theoretical maximum time for Kustomize to reconcile is 3x `spec.timeout` but this will only be the case when
+all of Dry Run, Apply, and Health Checking each take fully up to the maximum allowed time.
 
 The Kustomize Controller applies resource manifests to match the order in which they were rendered by the kustomize `build` call.  It therefore applies any
-custom resource definition (CRD), namespace, or cluster-scoped resources before their subordinate custom resource or namespace-scoped resources to that they
+custom resource definition (CRD), namespace, or cluster-scoped resources before their subordinate custom resource or namespace-scoped resources so that they
 will be available in the API for the resources that refer to or use them.
 
 ### Helm Controller reconciles HelmRelease resources


### PR DESCRIPTION
The Kustomize Controller's reconciling can take up to 3x `spec.timeout`

(This was an action item from today's Flux Dev meeting)

It seemed to fit naturally in this short paragraph about the Kustomize Server-Side Aply timeout that was missing details. Is there anywhere else we can highlight this, perhaps in the Kustomize controller docs as well