### PR TITLE
Add "FAQ" text to the description for FAQ page

### DIFF
--- a/content/en/flux/faq.md
+++ b/content/en/flux/faq.md
@@ -1,7 +1,7 @@
 ---
 title: "Frequently asked questions"
 linkTitle: "FAQ"
-description: "Flux and the GitOps Toolkit frequently asked questions."
+description: "Flux and the GitOps Toolkit frequently asked questions (FAQ)."
 weight: 100
 ---
 


### PR DESCRIPTION
Fix #1137

Not certain if this will help (the main FAQ page is not ranked at all when you search for "FAQ")