### PR TITLE
helm-op update script: read versions properly

### DIFF
--- a/content/en/legacy/helm-operator/get-started/using-helm.md
+++ b/content/en/legacy/helm-operator/get-started/using-helm.md
@@ -96,7 +96,7 @@ helm-operator-7cc7c798cc-kn26w   1/1     Running   0          18s
 ```console
 $ kubectl logs -f deploy/helm-operator
 ...
-ts=2020-01-01T12:00:00.55671.4.4Z caller=helm.go:71 component=helm version=v2 info="connected to Tiller" version="sem_ver:\"v2.16.3\" git_commit:\"1ee0254c86d4ed6887327dabed7aa7da29d7eb0d\" git_tree_state:\"clean\" " host=tiller-deploy.kube-system:44134 options="{Host: Port: Namespace:kube-system TLSVerify:false TLSEnable:true TLSKey:/etc/fluxd/helm/tls.key TLSCert:/etc/fluxd/helm/tls.crt TLSCACert: TLSHostname:}"
+ts=2020-01-01T12:00:00.556712443Z caller=helm.go:71 component=helm version=v2 info="connected to Tiller" version="sem_ver:\"v2.16.3\" git_commit:\"1ee0254c86d4ed6887327dabed7aa7da29d7eb0d\" git_tree_state:\"clean\" " host=tiller-deploy.kube-system:44134 options="{Host: Port: Namespace:kube-system TLSVerify:false TLSEnable:true TLSKey:/etc/fluxd/helm/tls.key TLSCert:/etc/fluxd/helm/tls.crt TLSCACert: TLSHostname:}"
 ```
 
 {{% alert color="info" title="Tip" %}}

--- a/hack/update-helm-op.sh
+++ b/hack/update-helm-op.sh
@@ -27,9 +27,11 @@ NEW_HELM_OP_RELEASE="$1"
 
 HELM_OP_DOCS="content/en/legacy/helm-operator"
 
+REGEX="$(echo $HELM_OP_RELEASE | sed 's/\./\\./g')"
+
 find ${HELM_OP_DOCS} \
     -iname '*.md' \
     -type f \
-    -exec sed -i "s/$HELM_OP_RELEASE/$NEW_HELM_OP_RELEASE/g" {} \;
+    -exec sed -i "s/$REGEX/$NEW_HELM_OP_RELEASE/g" {} \;
 
 echo "$NEW_HELM_OP_RELEASE" > $HELM_OP_RELEASE_FILE


### PR DESCRIPTION
This changed unrelated docs in
https://github.com/fluxcd/website/commit/34c756a6#diff-1df7f48852efaabb59a1fbc8c75a2f7a44b1eed0cece86e53835b364d6c74b0cR99

Signed-off-by: Daniel Holbach <daniel@weave.works>