### PR TITLE
changed "clusters" to "cluster" under Add podinfo repository to Flux

### DIFF
--- a/content/en/flux/get-started.md
+++ b/content/en/flux/get-started.md
@@ -123,7 +123,7 @@ podinfo is a tiny web application made with Go.
       --url=https://github.com/stefanprodan/podinfo \
       --branch=master \
       --interval=30s \
-      --export > ./clusters/my-cluster/podinfo-source.yaml
+      --export > ./cluster/my-cluster/podinfo-source.yaml
     ```
 
     The output is similar to:


### PR DESCRIPTION
changed "clusters" to "cluster" under Add podinfo repository to Flux because when the repo gets created it is ./cluster/my-cluster/flux-system but in the document it is clusters/my-cluster/flux-system

Signed-off-by: syedabrarali <50911126+syedabrarali@users.noreply.github.com>