### PR TITLE
add raffis/gitops-zombies to the tools list

### DIFF
--- a/content/en/ecosystem/index.md
+++ b/content/en/ecosystem/index.md
@@ -103,8 +103,9 @@ The functionality of Flux can be easily extended with ancillary utility tools. H
 
 | Source                                                                | Description                                                                                 | Documentation                                                                               |
 |-----------------------------------------------------------------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| [renovatebot/renovate](renovatebot/renovate)                          | Universal dependency update tool that fits into your workflows.                             | [Automated Dependency Updates for Flux](https://docs.renovatebot.com/modules/manager/flux/) |
 | [jgz/s3-auth-proxy](https://github.com/jgz/s3-auth-proxy)             | Creates a simple basic-auth proxy for an s3 bucket.                                         | [README](https://github.com/jgz/s3-auth-proxy#readme)                                       |
+| [raffis/gitops-zombies](https://github.com/raffis/gitops-zombies)     | Identify kubernetes resources which are not managed by GitOps                               | [README](https://github.com/raffis/gitops-zombies#readme)                                   |
+| [renovatebot/renovate](renovatebot/renovate)                          | Universal dependency update tool that fits into your workflows.                             | [Automated Dependency Updates for Flux](https://docs.renovatebot.com/modules/manager/flux/) |
 | [tarioch/flux-check-hook](https://github.com/tarioch/flux-check-hook) | A [pre-commit](https://pre-commit.com) that validates values of HelmRelease using helm lint | [README](https://github.com/tarioch/flux-check-hook#readme)                                 |
 
 </div>


### PR DESCRIPTION
Adds a new tool https://github.com/raffis/gitops-zombies to the tools list.

I quickly created a simple tool to identify workload which is not managed by GitOps. 
Quite useful on clusters which are getting migrated to gitops or where pruning is disabled, maybe this helps somebody.