### PR TITLE
remove Flux Legacy from landing page

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -4,7 +4,6 @@ description: >
   Flux is a set of continuous and progressive delivery solutions for Kubernetes, and they are open and extensible. 
   
   The APIs of Flux are stable now.
-  Now is the best time to start using Flux, or start your migration if you are a legacy user.
 ---
 
 {{% blocks/announce emoji="📢" url="/blog/2021/09/server-side-reconciliation-is-coming/" %}}
@@ -270,15 +269,6 @@ The canary analysis can be extended with webhooks for running system integration
     button1-url="/flux/gitops-toolkit/source-watcher/"
     button2-url="/flux/components/" %}}
 The set of APIs and controllers that make up the runtime for Flux. You can use the GitOps Toolkit to extend Flux, and to build your own systems for continuous delivery.
-{{% /blocks/project %}}
-
-{{% blocks/project title="Flux v1 and Helm Operator"
-    image="/img/logos/flux-horizontal-color.png" image-align="right" bg-color="white"
-    button1-url="/legacy/flux" button1-caption="Flux v1 Documentation" button1-color="blue"
-    button2-url="/legacy/helm-operator/" button2-caption="Helm Operator Documentation" button2-color="blue" %}}
-We owe our success and good reputation as GitOps project to Flux and Helm Operator. They are the v1 iteration of our project and currently in [maintenance mode](https://github.com/fluxcd/flux/issues/3320).
-
-We **strongly advise** everyone to familiarise themselves with the latest version of Flux and [start the process of migrating](/flux/migration/).
 {{% /blocks/project %}}
 
 {{% /blocks/section %}}


### PR DESCRIPTION
As Flux Legacy and Helm Operator will be archived Nov 1, we might want to remove them from the landing page and simplify our messaging already.

Signed-off-by: Daniel Holbach <daniel@weave.works>