### PR TITLE
FAQ: Should I be using Kustomize remote bases?

### DIFF
--- a/content/en/flux/faq.md
+++ b/content/en/flux/faq.md
@@ -205,6 +205,61 @@ To complete a rollout restart successfully, use the `flux-client-side-apply` fie
 kubectl --field-manager=flux-client-side-apply rollout restart ...
 ```
 
+### Should I be using Kustomize remote bases?
+
+For security and performance reasons, it is advised to disallow the usage of
+[remote bases](https://github.com/kubernetes-sigs/kustomize/blob/a7f4db7fb41e17b2c826a524f545e6174b4dc6ac/examples/remoteBuild.md)
+in Kustomize overlays. To enforce this setting, platform admins can set the `--no-remote-bases=true` flag for kustomize-controller.
+
+When using remote bases, the manifests are fetched over HTTPS from their remote source on every reconciliation e.g.:
+
+```yaml
+# infra/kyverno/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kyverno/kyverno/releases/download/v1.8.0/install.yaml
+```
+
+To take advantage of Flux's verification and caching features,
+you can replace the `kustomization.yaml` with a Flux source definition:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: kyverno
+  namespace: flux-system
+spec:
+  interval: 60m
+  url: oci://ghcr.io/kyverno/manifests/kyverno
+  ref: # pull the latest patch release evey hour
+    semver: 1.8.x
+  verify: # enable Cosign keyless verification
+    provider: cosign
+```
+
+Then to reconcile the manifests on a cluster, you'll use the ones from the verified source:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: kyverno
+  namespace: flux-system
+spec:
+  interval: 360m
+  prune: true
+  wait: true
+  timeout: 5m
+  sourceRef:
+    kind: OCIRepository
+    name: kyverno
+  path: ./
+  kubeConfig:
+    secretRef:
+      name: staging-cluster
+```
 
 ### What is the behavior of Kustomize used by Flux?
 


### PR DESCRIPTION
Encourage users to adopt Flux OCI distribution model and move away from Kustomize remote bases.