### PR TITLE
Fix URL for Weave Gitops Enterprise

### DIFF
--- a/content/en/ecosystem/index.md
+++ b/content/en/ecosystem/index.md
@@ -47,7 +47,7 @@ We are happy and proud to have you all as part of our community! :sparkling_hear
 | Giant Swarm | Kubernetes Platform     | [Documentation](https://docs.giantswarm.io/advanced/gitops/)                                  |
 | Gimlet      | Gimlet                  | [Documentation](https://gimlet.io/concepts/components/)                                       |
 | VMware      | Tanzu                   | [Product Page](https://tanzu.vmware.com/tanzu)                                                |
-| Weaveworks  | Weave Gitops Enterprise | [Product Page](https://www.weave.works/product/enterprise-flux/)                            |
+| Weaveworks  | Weave Gitops Enterprise | [Product Page](https://www.weave.works/enterprise-flux/)                            |
 
 ## Flux UIs
 


### PR DESCRIPTION
removed "/product" from the url. It was giving 404 at weave.works website. 

Signed-off-by: Mohamed F. Ahmed <MohamedFAhmed@users.noreply.github.com>