### PR TITLE
Update Dev install -> create kustomization from CLI

### DIFF
--- a/content/en/flux/installation.md
+++ b/content/en/flux/installation.md
@@ -607,7 +607,8 @@ flux create kustomization podinfo-default \
   --validation=client \
   --interval=10m \
   --health-check="Deployment/podinfo.default" \
-  --health-check-timeout=2m
+  --health-check-timeout=2m \
+  --target-namespace=default
 ```
 
 You can register Helm repositories and create Helm releases:


### PR DESCRIPTION
Add `target-namespace` to fix error message from `flux get kustomizations`:
> _Service/podinfo namespace not specified, error: the server could not find the requested resource_

Signed-off-by: Piotr Sobieszczański <piotr.sobieszczanski@gmail.com>