### PR TITLE
docs: remove graduation highlight

### DIFF
--- a/assets/scss/blocks/_blog.scss
+++ b/assets/scss/blocks/_blog.scss
@@ -30,7 +30,3 @@ body.td-home .deprecation-warning, body.td-blog .deprecation-warning, body.td-do
     text-decoration: underline;
 }
 
-#announce {
-    @extend .deprecation-warning;
-    background-color: #fffbd9;
-}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -35,7 +35,6 @@
           {{ end }}
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
-            {{ partial "graduation.html" . }}
             {{ block "main" . }}{{ end }}
           </main>
         </div>

--- a/layouts/partials/graduation.html
+++ b/layouts/partials/graduation.html
@@ -1,9 +1,0 @@
-<section id="announce">
-  <div class="content" style="padding: 10px;">
-    <h3 class="display-4">🎓
-      <a href="/blog/2022/11/flux-is-a-cncf-graduated-project/">
-        Flux is a CNCF Graduated project!
-      </a>
-    </h3>
-  </div>
-</section>


### PR DESCRIPTION
Towards EOY it might make sense to remove the highlight in our docs that informs users of Flux's graduation. It takes up quite a bit of screen-space on mobile, etc. Hopefully everyone learned about the news by the end of the year. :-)

Signed-off-by: Daniel Holbach <daniel@weave.works>