### PR TITLE
Clarify Google Source Repository bootstrap and upgrade

### DIFF
--- a/content/en/flux/use-cases/gcp-source-repository.md
+++ b/content/en/flux/use-cases/gcp-source-repository.md
@@ -6,6 +6,7 @@ weight: 10
 ---
 
 ### Cluster Creation
+
 To create a cluster with Google Cloud you can use the `gcloud` cli or the Google Cloud Console.
 
 The following command creates a cluster with the default configuration.
@@ -14,11 +15,13 @@ The following command creates a cluster with the default configuration.
 gcloud containers create sample-cluster
 ```
 
-For more details on how to create a GKE cluster with `gcloud`, please see [the Cloud SDK Documentation](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create)
+For more details on how to create a GKE cluster with `gcloud`,
+please see [the Cloud SDK Documentation](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create)
 
 ### Source Repository Creation
 
-Create a Cloud Source Repository that will hold your Flux installation manifests and other Kubernetes resources. Like the cluster, it can be created with the cli or the console.
+Create a Cloud Source Repository that will hold your Flux installation manifests and other Kubernetes resources.
+Like the cluster, it can be created with the CLI or the console.
 
 ### Flux Installation
 
@@ -34,15 +37,17 @@ flux bootstrap git \
 The above command will prompt you to add a deploy key to your repository, but Cloud Source Repository
 does not support repository or org-specific deploy keys. You may add the deploy key to a user's
 personal SSH keys, but take note that revoking the user's access to the repository will
-also revoke Flux's access. The better alternative is to create a machine-user whose sole purpose is
-to store credentials for automation. Using a machine-user also has the benefit of being able to be read-only or
-restricted to specific repositories if this is needed.
+also revoke Flux's access. The better alternative is to create a dedicated user for Flux.
 
-You can also use an ssh key that was already added to Cloud Source Repository by adding the `--private-key-file` and `--password` flags.
+You can also use a SSH key that was already added to Cloud Source Repository
+by adding the `--private-key-file` and `--password` flags.
 
 ### Flux Upgrade
 
-Flux compnents can be upgraded by running the `bootstrap` command again with the same arguments as before.
+To upgrade Flux, first you need to download the new CLI binary
+from [GitHub release](../installation.md#install-the-flux-cli).
+
+Flux components can be upgraded by running the `bootstrap` command again with the same arguments as before:
 
 ```sh
 flux bootstrap git \
@@ -51,10 +56,24 @@ flux bootstrap git \
 --path=clusters/my-cluster
 ```
 
+To upgrade Flux in a GitOps manner, you can generate the components manifests with the `install` command
+and commit the changes to your Git repository:
+
+```sh
+flux install --export > clusters/my-cluster/flux-system/gotk-components.yaml
+git add -A
+git commit -m "Update $(flux -v)"
+git push
+```
+
+Once Flux detects the changes in Git, it will upgrade itself.
+
 ### Secrets Management with SOPS and GCP KMS
 
-You would need to create GCP KMS key and have [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled on the GKE cluster. 
-Create an IAM service account that has `Cloud KMS CryptoKey Decrypter` role and allow the kustomize-cotroller service account to impersonate this service account by adding an IAM policy binding between it and the IAM service account.
+You would need to create GCP KMS key and have
+[workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) enabled on the GKE cluster. 
+Create an IAM service account that has `Cloud KMS CryptoKey Decrypter` role and allow the kustomize-controller
+service account to impersonate this service account by adding an IAM policy binding between it and the IAM service account.
 
 ```sh
 gcloud iam service-accounts add-iam-policy-binding <iam-service-account>@<project-name>.iam.gserviceaccount.com \
@@ -62,13 +81,19 @@ gcloud iam service-accounts add-iam-policy-binding <iam-service-account>@<projec
     --member "serviceAccount:<project-name>.svc.id.goog[flux-system/kustomize-controller]"
 ```
 
-Patch the kustomize-controller with the `iam.gke.io/gcp-service-account=<iam-service-account>@<project-name>.iam.gserviceaccount.com` annotation so that it can access GCP KMS. You can start commiting your encrypted files to git with the proper GCP KMS configuration.
+Patch the kustomize-controller with the
+`iam.gke.io/gcp-service-account=<iam-service-account>@<project-name>.iam.gserviceaccount.com`
+annotation so that it can access GCP KMS.
+You can start committing your encrypted files to Git with the proper GCP KMS configuration.
 
 See the [Mozilla SOPS AWS Guide](../guides/mozilla-sops.md#google-cloud) for further detail.
 
 ### Image Updates with Google Container Registry
 
-You will need to create an GCR registry. Most new GKE cluster by default have access to Google Container Registry in the same project. But if you have enabled Workload Identity on your cluster, you would need to create an IAM service account that has access to GCR.
+You will need to create an GCR registry. Most new GKE cluster by default have access to
+Google Container Registry in the same project.
+But if you have enabled Workload Identity on your cluster,
+you would need to create an IAM service account that has access to GCR.
 
 You may need to update your Flux install to include additional components:
 
@@ -81,4 +106,5 @@ flux bootstrap git \
 ```
 
 Follow the [Image Update Automation Guide](../guides/image-update.md) and see the
-[GCR specific section](../guides/image-update.md#using-native-gcp-gcr-auto-login) for more details on how to configure image update automation for GKE.
+[GCR specific section](../guides/image-update.md#using-native-gcp-gcr-auto-login)
+for more details on how to configure image update automation for GKE.


### PR DESCRIPTION
Address some of feedback from https://github.com/fluxcd/flux2/discussions/3361 

Changes:
- Remove the machine-user reference
- Tell people to create Flux user
- Explain how to upgrade