### PR TITLE
Fix git rev-list command in sortable image tags guide

### DIFF
--- a/content/en/flux/guides/sortable-image-tags.md
+++ b/content/en/flux/guides/sortable-image-tags.md
@@ -47,7 +47,7 @@ and you don't rewrite the branch in question:
 
 ```bash
 $ # commits in branch
-$ git --rev-list --count HEAD
+$ git rev-list --count HEAD
 1504
 ```
 


### PR DESCRIPTION
`rev-list` is a subcommand of git, not an argument.

Signed-off-by: Johannes Wienke <languitar@semipol.de>