### PR TITLE
Document CacheSecretsAndConfigMaps feature flag in source-controller

### DIFF
--- a/content/en/flux/components/helm/options.md
+++ b/content/en/flux/components/helm/options.md
@@ -35,6 +35,8 @@ please see the [bootstrap cheatsheet](../../cheatsheets/bootstrap.md).
 | `--no-cross-namespace-refs`           | boolean  | When set to true, references between custom resources are allowed only if the reference and the referee are in the same namespace.                     |
 | `--requeue-dependency`                | duration | The interval at which failing dependencies are reevaluated. (default 30s)                                                                              |
 | `--watch-all-namespaces`              | boolean  | Watch for custom resources in all namespaces, if set to false it will only watch the runtime namespace. (default true)                                 |
+| `--feature-gates`                     | mapStringBool | A comma separated list of key=value pairs defining the state of experimental features.                                             |
+
 
 ### Feature Gates
 

--- a/content/en/flux/components/source/options.md
+++ b/content/en/flux/components/source/options.md
@@ -51,3 +51,4 @@ please see the [bootstrap cheatsheet](../../cheatsheets/bootstrap.md).
 |-----------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | `OptimizedGitClones`              | `true`        | Optimises Git resource usage by only cloning repositories when the HEAD commit changed since last reconciliation.                     |
 | `ForceGoGitImplementation`        | `true`        | Soft-deprecates `libgit2` by ignoring the value set for `spec.gitImplementation`, and using `go-git` for all reconciliations instead. |
+| `CacheSecretsAndConfigMaps`       | `false`       | Configures the caching of Secrets and ConfigMaps by the controller-runtime client. When enabled, it will cache both object types, resulting in increased memory usage and cluster-wide RBAC permissions (list and watch). |


### PR DESCRIPTION
This PR depends on this one: https://github.com/fluxcd/source-controller/pull/989

Reference issue: https://github.com/fluxcd/flux2/issues/3426

Also: Added the --feature-gates flag to the helm controller docs from #1316