### PR TITLE
image-reflector-controller v1beta2 updates

### DIFF
--- a/content/en/flux/cheatsheets/bootstrap.md
+++ b/content/en/flux/cheatsheets/bootstrap.md
@@ -48,7 +48,7 @@ patches:
   - patch: |
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --aws-autologin-for-ecr=true
+        value: --concurrent=5
     target:
       kind: Deployment
       name: "image-reflector-controller"

--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -612,7 +612,7 @@ and [GitHub Actions Auto Pull Request](/flux/use-cases/gh-actions-auto-pr/).
 Define an image repository and a semver policy for the OCI artifact:
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: podinfo-oci
@@ -621,7 +621,7 @@ spec:
   image: ghcr.io/stefanprodan/manifests/podinfo
   interval: 5m
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: podinfo-oci
@@ -658,7 +658,7 @@ change to Git.
 Define an image repository and a semver policy for the Helm chart:
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: podinfo-chart
@@ -667,7 +667,7 @@ spec:
   image: ghcr.io/stefanprodan/charts/podinfo
   interval: 5m
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: podinfo-chart

--- a/content/en/flux/gitops-toolkit/packages.md
+++ b/content/en/flux/gitops-toolkit/packages.md
@@ -119,8 +119,8 @@ Import package
 
 ```go
 import (
-	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1alpha2"
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1alpha2"
+	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
 )
 ```
 
@@ -128,9 +128,9 @@ API Types
 
 | Name | Version |
 |---|---|
-| [ImageRepository](../components/image/imagerepositories.md) | v1alpha2 |
-| [ImagePolicy](../components/image/imagepolicies.md) | v1alpha2 |
-| [ImageUpdateAutomation](../components/image/imageupdateautomations.md) | v1alpha2 |
+| [ImageRepository](../components/image/imagerepositories.md) | v1beta2 |
+| [ImagePolicy](../components/image/imagepolicies.md) | v1beta2 |
+| [ImageUpdateAutomation](../components/image/imageupdateautomations.md) | v1beta1 |
 
 ## CRUD Example
 

--- a/content/en/flux/guides/cron-job-image-auth.md
+++ b/content/en/flux/guides/cron-job-image-auth.md
@@ -7,7 +7,7 @@ weight: 90
 
 ## Image Repository Authentication
 
-While [native authentication mechanisms](image-update.md/#imageRepository-cloud-providers-authentication) 
+While [native authentication mechanisms](../components/image/imagerepositories.md#provider)
 are available, using a cron job is the preferred way of syncing image repository credentials for
 multi-tenancy as the controller cannot natively get access to the image repository.
 
@@ -151,8 +151,6 @@ spec:
 ```
 
 ### GCP Container Registry
-
-#### Using Native GCP GCR Auto-Login
 
 #### Using access token [short-lived]
 

--- a/content/en/flux/guides/sortable-image-tags.md
+++ b/content/en/flux/guides/sortable-image-tags.md
@@ -153,7 +153,7 @@ Here is an example that filters for only images built from `main` branch, and se
 recent according to a timestamp (created with `date +%s`) or according to the run number (`github.run_number` for example):
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: image-repo-policy
@@ -173,7 +173,7 @@ spec:
 If you don't care about the branch, that part can be a wildcard in the pattern:
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: image-repo-policy

--- a/content/en/flux/migration/flux-v1-automation-migration.md
+++ b/content/en/flux/migration/flux-v1-automation-migration.md
@@ -417,7 +417,7 @@ $ flux create image repository podinfo-image \
     --export > ./$AUTO_PATH/podinfo-image.yaml
 $ cat ./$AUTO_PATH/podinfo-image.yaml
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: podinfo-image
@@ -523,7 +523,7 @@ Say you want to filter for only images that are from `main` branch, and pick the
 `ImagePolicy` would look like this:
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: my-app-policy
@@ -567,7 +567,7 @@ example, you might put a target environment as well as the version in your image
 Then you would use an `ImagePolicy` similar to this one:
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: my-app-policy
@@ -598,7 +598,7 @@ $ flux create image policy my-app-policy \
     --export > ./$AUTO_PATH/my-app-policy.yaml
 $ cat ./$AUTO_PATH/my-app-policy.yaml
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: my-app-policy

--- a/hack/import-flux2-assets.sh
+++ b/hack/import-flux2-assets.sh
@@ -152,8 +152,8 @@ gen_crd_doc() {
   # image-*-controller CRDs; these use the same API group
   IMG_REFL_VER="$(controller_version image-reflector-controller)"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/api/image-reflector.md" "$COMPONENTS_DIR/image/reflector-api.md" "HUGETABLE"
-  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1beta1/imagerepositories.md" "$COMPONENTS_DIR/image/imagerepositories.md"
-  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1beta1/imagepolicies.md" "$COMPONENTS_DIR/image/imagepolicies.md"
+  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1beta2/imagerepositories.md" "$COMPONENTS_DIR/image/imagerepositories.md"
+  gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-reflector-controller/$IMG_REFL_VER/docs/spec/v1beta2/imagepolicies.md" "$COMPONENTS_DIR/image/imagepolicies.md"
 
   IMG_AUTO_VER="$(controller_version image-automation-controller)"
   gen_crd_doc "https://raw.githubusercontent.com/fluxcd/image-automation-controller/$IMG_AUTO_VER/docs/api/image-automation.md" "$COMPONENTS_DIR/image/automation-api.md" "HUGETABLE"


### PR DESCRIPTION
- Update the mention of old API version.
- Add example of the latest ten tags in the scan result.
- Remove section about authentication with old autologin flags and add
  reference to the spec docs provider section.
- Add ImagePolicy examples section that are no longer in the spec docs.
- Update link to native auth docs and remove empty section about GCP
native auto-login.