### PR TITLE
bugfix patch for notifications fluxcd v0.39.0 tf-controller v0.13.1

### DIFF
--- a/content/en/flux/cheatsheets/bootstrap.md
+++ b/content/en/flux/cheatsheets/bootstrap.md
@@ -513,12 +513,18 @@ patches:
       - op: add
         path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
         value: Terraform
+      - op: add
+        path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/eventSources/items/properties/kind/enum/-
+        value: Terraform
     target:
       kind: CustomResourceDefinition
       name:  alerts.notification.toolkit.fluxcd.io
   - patch: |
       - op: add
         path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
+        value: Terraform
+      - op: add
+        path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/resources/items/properties/kind/enum/-
         value: Terraform
     target:
       kind: CustomResourceDefinition


### PR DESCRIPTION
Hi

While configuring tf-controller to send notifications to fluxcd, I've followed the current instructions in [enable-notifications-for-third-party-controllers](https://fluxcd.io/flux/cheatsheets/bootstrap/#enable-notifications-for-third-party-controllers) but continuously got an error and Terraform-CRD notifications did not worked.

I've investigated and with these proposed changes to the patch, the notifications worked again, as intended. 

It could be good to add these to the instructions in [enable-notifications-for-third-party-controllers](https://fluxcd.io/flux/cheatsheets/bootstrap/#enable-notifications-for-third-party-controllers) to help future users

I've used recent versions of fluxcd and tf-controller:   
- tf-controller v0.13.1
- fluxcd v0.39.0

Keep up the great work - cheers