### PR TITLE
fix link to keyless signatures docs

### DIFF
--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -389,7 +389,7 @@ spec:
 
 {{% alert color="info" title="Cosign Keyless" %}}
 For publicly available OCI artifacts, which are signed using
-the [Cosign Keyless](https://github.com/sigstore/cosign/blob/main/KEYLESS.md)
+the [Cosign Keyless](https://docs.sigstore.dev/cosign/keyless/)
 method, you can enable the verification by omitting the `.verify.secretRef` field.
 
 Note that keyless verification is an **experimental feature**, using


### PR DESCRIPTION
The old link has been deprecated and points to this new one.

Signed-off-by: Max Jonas Werner <max@e13.dev>
