### PR TITLE
Prevent future embarrassment by changing Slack channel example

### DIFF
--- a/content/en/flagger/install/flagger-install-on-google-cloud.md
+++ b/content/en/flagger/install/flagger-install-on-google-cloud.md
@@ -360,7 +360,7 @@ helm upgrade -i flagger flagger/flagger \
 --set crd.create=false \
 --set metricsServer=http://prometheus.istio-system:9090 \
 --set slack.url=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK \
---set slack.channel=general \
+--set slack.channel=some-channel-name \
 --set slack.user=flagger
 ```
 

--- a/content/en/flagger/tutorials/kubernetes-blue-green.md
+++ b/content/en/flagger/tutorials/kubernetes-blue-green.md
@@ -39,7 +39,7 @@ helm upgrade -i flagger flagger/flagger \
 --reuse-values \
 --namespace flagger \
 --set slack.url=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK \
---set slack.channel=general \
+--set slack.channel=some-channel-name \
 --set slack.user=flagger
 ```
 

--- a/content/en/flagger/usage/alerting.md
+++ b/content/en/flagger/usage/alerting.md
@@ -24,7 +24,7 @@ Once the webhook has been generated. Flagger can be configured to send Slack not
 helm upgrade -i flagger flagger/flagger \
 --set slack.url=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK \
 --set slack.proxy=my-http-proxy.com \ # optional http/s proxy
---set slack.channel=general \
+--set slack.channel=some-channel-name \
 --set slack.user=flagger \
 --set clusterName=my-cluster
 ```

--- a/content/en/flux/guides/notifications.md
+++ b/content/en/flux/guides/notifications.md
@@ -47,7 +47,7 @@ metadata:
   namespace: flux-system
 spec:
   type: slack
-  channel: general
+  channel: some-channel-name
   secretRef:
     name: slack-url
 ```

--- a/content/en/flux/migration/flux-v1-migration.md
+++ b/content/en/flux/migration/flux-v1-migration.md
@@ -269,7 +269,7 @@ With Flux v2, create an alert provider for a Slack channel:
 ```sh
 flux create alert-provider slack \
   --type=slack \
-  --channel=general \
+  --channel=some-channel-name \
   --address=https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
 ```
 


### PR DESCRIPTION
This PR changes the suggested Slack channel from "general' to hopefully prevent users that blindly copypasta like myself from alerting their entire company :sweat_smile:.

TIL Slack webhook URLs are not solely scoped to the channels they are created with and can be overridden.

![image](https://user-images.githubusercontent.com/959573/223865321-aff6d21c-2a1c-43ee-95d6-c9345109b4ef.png)
