### PR TITLE
Add documentation for new `--deploy-token-auth` option

### DIFF
--- a/content/en/flux/installation.md
+++ b/content/en/flux/installation.md
@@ -284,6 +284,18 @@ flux bootstrap gitlab \
   --personal
 ```
 
+To use a [GitLab deploy token](https://docs.gitlab.com/ee/user/project/deploy_tokens/) instead of your personal access token
+or an SSH deploy key, you can specify the `--deploy-token-auth` option:
+
+```sh
+flux bootstrap gitlab \
+  --owner=my-gitlab-username \
+  --repository=my-repository \
+  --branch=master \
+  --path=clusters/my-cluster \
+  --deploy-token-auth
+```
+
 To run the bootstrap for a repository using deploy keys for authentication, you have to specify the SSH hostname:
 
 ```sh


### PR DESCRIPTION
This change documents the possibility to use a deploy token instead of a personal access token or an SSH deploy key.

This feature is implemented with:

* https://github.com/fluxcd/flux2/pull/3654

and was discussed in:

* https://github.com/fluxcd/flux2/discussions/3595

/cc @makkes 