### PR TITLE
exclude v1 from API spec imports

### DIFF
--- a/hack/import-flux2-assets.sh
+++ b/hack/import-flux2-assets.sh
@@ -66,7 +66,7 @@ controller_version() {
       cat /tmp/releases
       exit 1
   fi
-  jq -r '.[] | .tag_name' < /tmp/releases | sort -V | tail -n 1
+  jq -r '.[] | .tag_name' < /tmp/releases | grep -v '^v1' | sort -V | tail -n 1
 }
 
 gen_crd_doc() {


### PR DESCRIPTION
We changed the directory structure of the specs in the respective controllers' v1 versions. Until a full Flux release has been cut we need to exclude all v1 versions from being imported until #1427 has landed.
