### PR TITLE
Doc OpenShift fix variable substitution $NS->${NS}

### DIFF
--- a/content/en/flux/use-cases/openshift.md
+++ b/content/en/flux/use-cases/openshift.md
@@ -51,12 +51,12 @@ Before installing Flux with CLI, you need to set the **nonroot** SCC for all con
 
 ```sh
 NS="flux-system"
-oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:kustomize-controller
-oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:helm-controller
-oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:source-controller
-oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:notification-controller
-oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:image-automation-controller
-oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:image-reflector-controller
+oc adm policy add-scc-to-user nonroot system:serviceaccount:${NS}:kustomize-controller
+oc adm policy add-scc-to-user nonroot system:serviceaccount:${NS}:helm-controller
+oc adm policy add-scc-to-user nonroot system:serviceaccount:${NS}:source-controller
+oc adm policy add-scc-to-user nonroot system:serviceaccount:${NS}:notification-controller
+oc adm policy add-scc-to-user nonroot system:serviceaccount:${NS}:image-automation-controller
+oc adm policy add-scc-to-user nonroot system:serviceaccount:${NS}:image-reflector-controller
 ```
 
 Also, you have to patch your Kustomization to remove the SecComp Profile and enforce `runUserAs` to the same UID provided by the images to prevent OpenShift to alter the user expected by our controllers, before bootstrapping by.


### PR DESCRIPTION
On macOS with Zsh the OpenShift instructions fail to execute correctly:

Expected:
```
NS="flux-system"                                                                                                                
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:kustomize-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:helm-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:source-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:notification-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:image-automation-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:image-reflector-controller
```

Output:
```
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "kustomize-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "helm-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "source-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "notification-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "image-automation-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "image-reflector-controller"
```

-------

Actual:
```
NS="flux-system"
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:kustomize-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:helm-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:source-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:notification-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:image-automation-controller
oc adm policy add-scc-to-user nonroot system:serviceaccount:$NS:image-reflector-controller
```

Output:
```
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "kustomize-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "system:serviceaccount:.elm-controller" <-----------
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "system:serviceaccount:flux-systemller" <-----------
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "notification-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "image-automation-controller"
clusterrole.rbac.authorization.k8s.io/system:openshift:scc:nonroot added: "image-reflector-controller"
```