### PR TITLE
File name mismatch between the error and example's spec

### DIFF
--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -537,7 +537,7 @@ fetch the chart. To determine why the `HelmChart` fails to produce an artifact, 
 ```sh
 $ kubectl get helmcharts --all-namespaces
 NAME    READY   STATUS
-mongodb False   failed to locate override values file: values-prod.yaml
+mongodb False   failed to locate override values file: values-production.yaml
 ```
 
 ## Configure notifications


### PR DESCRIPTION
Match the file name that appears in the error with the example.

![image](https://user-images.githubusercontent.com/4607250/235981296-49fed1fc-adf0-4191-a034-9c50bb769dd2.png)
