### PR TITLE
docs: fix GitHub Pull Request Action configuration syntax

### DIFF
--- a/content/en/flux/use-cases/gh-actions-auto-pr.md
+++ b/content/en/flux/use-cases/gh-actions-auto-pr.md
@@ -32,7 +32,7 @@ To create the pull request whenever automation creates a new branch, in your man
 # ./.github/workflows/staging-auto-pr.yaml
 name: Staging Auto-PR
 on:
-  create:
+  push:
     branches: ['staging']
 
 jobs:


### PR DESCRIPTION
`create` isn't valid syntax and tries to create a PR for every branch pushed