### PR TITLE
Update GitHub Actions examples syntax + actions versions

### DIFF
--- a/content/en/flux/guides/sortable-image-tags.md
+++ b/content/en/flux/guides/sortable-image-tags.md
@@ -91,17 +91,17 @@ jobs:
 
     # These are prerequisites for the docker build step
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and publish container image with tag
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
           push: true
           context: .
@@ -124,17 +124,17 @@ jobs:
     steps:
     # These are prerequisites for the docker build step
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and publish container image with tag
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
           push: true
           context: .

--- a/content/en/flux/use-cases/gh-actions-app-builder.md
+++ b/content/en/flux/use-cases/gh-actions-app-builder.md
@@ -57,9 +57,10 @@ jobs:
             BUILD_ID=${GITHUB_REF/refs\/tags\//}
             LATEST_ID=latest
           fi
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=BUILD_ID::${BUILD_ID}
-          echo ::set-output name=LATEST_ID::${LATEST_ID}
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+          echo BUILD_ID=${BUILD_ID} >> $GITHUB_OUTPUT
+          echo LATEST_ID=${LATEST_ID} >> $GITHUB_OUTPUT
+
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -145,9 +146,9 @@ Another sensible choice could be to build and push canary images only from the `
         BUILD_ID=${GITHUB_REF/refs\/tags\//}
         LATEST_ID=latest
       fi
-      echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      echo ::set-output name=BUILD_ID::${BUILD_ID}
-      echo ::set-output name=LATEST_ID::${LATEST_ID}
+      echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+      echo BUILD_ID=${BUILD_ID} >> $GITHUB_OUTPUT
+      echo LATEST_ID=${LATEST_ID} >> $GITHUB_OUTPUT
 ```
 
 This script has no external effects, it only takes some inputs from environment variables set by GitHub Actions and calculates them into several outputs: `BUILD_ID` and `LATEST_ID`. The `BUILD_DATE` is also exported as an output for informational purposes and is not used elsewhere in the workflow.

--- a/content/en/flux/use-cases/gh-actions-app-builder.md
+++ b/content/en/flux/use-cases/gh-actions-app-builder.md
@@ -62,20 +62,20 @@ jobs:
           echo ::set-output name=LATEST_ID::${LATEST_ID}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: |

--- a/content/en/flux/use-cases/gh-actions-auto-pr.md
+++ b/content/en/flux/use-cases/gh-actions-auto-pr.md
@@ -40,7 +40,7 @@ jobs:
     name: Open PR to main
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       name: checkout
 
     - uses: repo-sync/pull-request@v2

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -121,7 +121,7 @@ jobs:
         id: staging
         run: |
           VERSION=${{ github.event.client_payload.metadata.revision }}
-          echo ::set-output name=VERSION::${VERSION}
+          echo VERSION=${VERSION} >> $GITHUB_OUTPUT
       # Patch the chart version in the production Helm release manifest.
       - name: Set chart version in production
         id: production

--- a/content/en/flux/use-cases/gh-actions-manifest-generation.md
+++ b/content/en/flux/use-cases/gh-actions-manifest-generation.md
@@ -99,8 +99,8 @@ jobs:
         id: prep
         run: |
           VERSION=${GITHUB_SHA::8}
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=VERSION::${VERSION}
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+          echo VERSION=${VERSION} >> $GITHUB_OUTPUT
 
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -121,8 +121,8 @@ In the `Prepare` step, even before the clone, GitHub Actions provides metadata a
 ```bash
 # excerpt from above - set two outputs named "VERSION" and "BUILD_DATE"
 VERSION=${GITHUB_SHA::8}
-echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-echo ::set-output name=VERSION::${VERSION}
+echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+echo VERSION=${VERSION} >> $GITHUB_OUTPUT
 ```
 
 {{% alert title="When migrating to Flux v2" %}}
@@ -297,8 +297,8 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF/refs\/tags\//}
           fi
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=VERSION::${VERSION}
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+          echo VERSION=${VERSION} >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -385,8 +385,8 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/release/* ]]; then
             VERSION=${GITHUB_REF/refs\/tags\/release\//}
           fi
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=VERSION::${VERSION}
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+          echo VERSION=${VERSION} >> $GITHUB_OUTPUT
 
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -1175,8 +1175,8 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF/refs\/tags\//}
           fi
-          echo ::set-output name=BUILD_DATE::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=VERSION::${VERSION}
+          echo BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_OUTPUT
+          echo VERSION=${VERSION} >> $GITHUB_OUTPUT
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/content/en/flux/use-cases/gh-actions-manifest-generation.md
+++ b/content/en/flux/use-cases/gh-actions-manifest-generation.md
@@ -103,7 +103,7 @@ jobs:
           echo ::set-output name=VERSION::${VERSION}
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update manifests
         run: ./update-k8s.sh $GITHUB_SHA
@@ -301,20 +301,20 @@ jobs:
           echo ::set-output name=VERSION::${VERSION}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: kingdonb/any-old-app:${{ steps.prep.outputs.VERSION }}
@@ -389,7 +389,7 @@ jobs:
           echo ::set-output name=VERSION::${VERSION}
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup kubecfg CLI
         uses: kingdonb/kubecfg/action@main
@@ -1179,7 +1179,7 @@ jobs:
           echo ::set-output name=VERSION::${VERSION}
 
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update manifests
         run: ./update-k8s.sh $GITHUB_SHA


### PR DESCRIPTION
Primary purpose is to update the GH Actions syntax in preparation for the [deprecation of `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), in order to keep the examples functional in the future.

In addition to that, I made some straightforward updates for the well-known GH Actions used in the examples like `docker/login-action`, `docker/setup-*` and `actions/checkout`.