### PR TITLE
docs: updated zero-downtime-deployments.md

### DIFF
--- a/content/en/flagger/tutorials/zero-downtime-deployments.md
+++ b/content/en/flagger/tutorials/zero-downtime-deployments.md
@@ -28,19 +28,12 @@ You application should expose a HTTP endpoint that Kubernetes can call to determ
 
 ```yaml
 livenessProbe:
-  exec:
-    command:
-    - wget
-    - --quiet
-    - --tries=1
-    - --timeout=4
-    - --spider
-    - http://localhost:8080/healthz
+  httpGet:
+    path: /healthz
+    port: 8080
   timeoutSeconds: 5
   initialDelaySeconds: 5
 ```
-
-If you've enabled mTLS, you'll have to use `exec` for liveness and readiness checks since kubelet is not part of the service mesh and doesn't have access to the TLS cert.
 
 ## Readiness health check
 
@@ -48,20 +41,21 @@ You application should expose a HTTP endpoint that Kubernetes can call to determ
 
 ```yaml
 readinessProbe:
-  exec:
-    command:
-    - wget
-    - --quiet
-    - --tries=1
-    - --timeout=4
-    - --spider
-    - http://localhost:8080/readyz
+  httpGet:
+    path: /readyz
+    port: 8080
   timeoutSeconds: 5
   initialDelaySeconds: 5
   periodSeconds: 5
 ```
 
-If your app depends on external services, you should check if those services are available before allowing Kubernetes to route traffic to an app instance. Keep in mind that the Envoy sidecar can have a slower startup than your app. This means that on application start you should retry for at least a couple of seconds any external connection.
+## Hold application until Service Mesh Sidecar starts
+
+If your app depends on external services, you should check if those services are available before allowing Kubernetes to route traffic to an app instance. Keep in mind that the service mesh sidecar proxy can have a slower startup than your app. This means that on application start you should retry for at least a couple of seconds any external connection.
+
+How to avoid this on various service mesh:
+- Istio: [holdApplicationUntilProxyStarts=true](https://istio.io/latest/docs/ops/common-problems/injection/#pod-or-containers-start-with-network-issues-if-istio-proxy-is-not-ready)
+- Linkerd: [config.linkerd.io/proxy-await=enabled](https://linkerd.io/2.13/reference/proxy-configuration/)
 
 ## Graceful shutdown
 
@@ -81,38 +75,19 @@ spec:
             exec:
               command:
               - sleep
-              - "10"
+              - "15"
 ```
 
-Your app container should have a `preStop` hook that delays the container shutdown. This will allow the service mesh to drain the traffic and remove this pod from all other Envoy sidecars before your app becomes unavailable.
+In the example above, `terminationGracePeriodSeconds` is 60, and the preStop hook takes 15 seconds to complete, and the Container will have 45 seconds to stop normally
 
-## Delay Envoy shutdown
+This will allow the Kubernetes to drain the traffic and remove this pod from all other [Endpoints](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) and Envoy sidecars before your app becomes unavailable.
 
-Even if your app reacts to `SIGTERM` and tries to complete the inflight requests before shutdown, that doesn't mean that the response will make it back to the caller. If the Envoy sidecar shuts down before your app, then the caller will receive a 503 error.
+## Delay Service mesh proxy shutdown
 
-To mitigate this issue you can add a `preStop` hook to the Istio proxy and wait for the main app to exit before Envoy exits.
+Even if your app reacts to `SIGTERM` and tries to complete the inflight requests before shutdown, that doesn't mean that the response will make it back to the caller. If the service mesh sidecar shuts down before your app, then the caller will receive a 503 error.
 
-```bash
-#!/bin/bash
-set -e
-if ! pidof envoy &>/dev/null; then
-  exit 0
-fi
-
-if ! pidof pilot-agent &>/dev/null; then
-  exit 0
-fi
-
-while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l | xargs) -ne 0 ]; do
-  sleep 1;
-done
-
-exit 0
-```
-
-You'll have to build your own Envoy docker image with the above script and modify the Istio injection webhook with the `preStop` directive.
-
-Thanks to Stono for his excellent [tips](https://github.com/istio/istio/issues/12183) on minimising 503s.
+- Istio: configure via the parameter [terminationDrainDuration](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/) in the Istio `ProxyConfig` and wait for the existing connections to complete in the app
+- Linkerd: [config.linkerd.io/shutdown-grace-period](https://linkerd.io/2.13/tasks/graceful-shutdown/#configuration-options-for-graceful-shutdown)
 
 ## Resource requests and limits
 
@@ -142,24 +117,22 @@ Note that without resource requests the horizontal pod autoscaler can't determin
 A production environment should be able to handle traffic bursts without impacting the quality of service. This can be achieved with Kubernetes autoscaling capabilities. Autoscaling in Kubernetes has two dimensions: the Cluster Autoscaler that deals with node scaling operations and the Horizontal Pod Autoscaler that automatically scales the number of pods in a deployment.
 
 ```yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: app
-  minReplicas: 2
-  maxReplicas: 4
+  minReplicas: 3
+  maxReplicas: 12
   metrics:
   - type: Resource
     resource:
       name: cpu
-      targetAverageValue: 900m
-  - type: Resource
-    resource:
-      name: memory
-      targetAverageValue: 768Mi
+      target:
+        type: Utilization
+        averageUtilization: 50
 ```
 
 The above HPA ensures your app will be scaled up before the pods reach the CPU or memory limits.
@@ -185,4 +158,3 @@ spec:
 ```
 
 When the HPA scales down your app, your users could run into 503 errors. The above configuration will make Envoy retry the HTTP requests that failed due to gateway errors.
-


### PR DESCRIPTION
1. Removed `wget` HTTP probes:
    - Istio solves both these problems by rewriting the application PodSpec readiness/liveness probe, so that the probe request is sent to the [sidecar agent](https://istio.io/latest/docs/reference/commands/pilot-agent/). For HTTP and gRPC requests, the sidecar agent redirects the request to the application and strips the response body, only returning the response code. For TCP probes, the sidecar agent will then do the port check while avoiding the traffic redirection. https://istio.io/latest/docs/ops/configuration/mesh/app-health-check/
    - Linkerd automatically authorizes probes to pods https://linkerd.io/2.13/features/server-policy/#default-authorizations
2. Added instruction how to hold application until Service Mesh Sidecar starts
3. Outdated `Delay Envoy shutdown` replaced with `Delay Service mesh proxy shutdown`
4. Updated HPA api version to `autoscaling/v2` that available since v1.23