### PR TITLE
Add @kingdonb to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,6 +7,7 @@ In alphabetical order:
 Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
 Scott Rigby, Independent <scott@r6by.com> (github: @scottrigby, slack: scottrigby)
 Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
+Kingdon Barrett, Weaveworks <kingdon@weave.works> (github: @kingdonb, slack: Kingdon B)
 
 Retired maintainers:
 


### PR DESCRIPTION
@hiddeco @stefanprodan @scottrigby 

I volunteer as a maintainer for fluxcd/website

I reviewed the maintainer [community roles doc](https://github.com/fluxcd/community/blob/main/community-roles.md#maintainer) which is quite familiar to me now, and it looks like I meet all of the criteria.

For easy reference, my history as a contributor here:
* PRs I contributed: https://github.com/fluxcd/website/issues?q=author%3Akingdonb
* Issues where I was involved: https://github.com/fluxcd/website/issues?q=is%3Aopen+mentions%3A%40me

I am also currently a maintainer in the `community` and was also maintainer on the `fluxcd/flux` repo that got archived.

Adding this will be a big help, so I can review and merge PRs from @mehak151 as we begin to get rolling on the GSoD work ✅ 