### PR TITLE
Rename 'Migrate' to 'Migrate from Flux v1'

### DIFF
--- a/content/en/flux/migration/_index.md
+++ b/content/en/flux/migration/_index.md
@@ -2,7 +2,7 @@
 title: "Migrate from Flux v1"
 linkTitle: "Migrate from Flux v1"
 description: "Migration guides for Flux v1 and Helm Operator users."
-weight: 60
+weight: 150
 ---
 
 {{% alert color="danger" title="Flux Legacy has reached end of life." %}}

--- a/content/en/flux/migration/_index.md
+++ b/content/en/flux/migration/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Migration"
-linkTitle: "Migration"
+title: "Migrate from Flux v1"
+linkTitle: "Migrate from Flux v1"
 description: "Migration guides for Flux v1 and Helm Operator users."
 weight: 60
 ---


### PR DESCRIPTION
Addressing a part of this feedback by @dholbach: https://github.com/fluxcd/website/issues/718