### PR TITLE
Fix ordering of versions when pulling component docs

### DIFF
--- a/hack/import-flux2-assets.sh
+++ b/hack/import-flux2-assets.sh
@@ -66,7 +66,8 @@ controller_version() {
       cat /tmp/releases
       exit 1
   fi
-  jq -r '.[] | .tag_name' < /tmp/releases | sort -V | tail -n 1
+
+  jq -r '.[] | .tag_name' < /tmp/releases | sed 's/.*\///' | awk '{ if ($1 ~ /-/) print; else print $0"_" ; }' | sort -rV | sed 's/_$//' | head -n1
 }
 
 gen_crd_doc() {


### PR DESCRIPTION
`sort -V` doesn't properly sort according to semver. This led to an old version of NC (1.0.0-rc.4) being pulled instead of the latest 1.0.0.