### PR TITLE
docs: Use DoesNotExist operator in shard selector

### DIFF
--- a/content/en/flux/cheatsheets/sharding.md
+++ b/content/en/flux/cheatsheets/sharding.md
@@ -146,15 +146,15 @@ patches:
   - target:
       kind: Deployment
       name: "(source-controller|kustomize-controller|helm-controller)"
-      annotationSelector: "sharding.fluxcd.io/role notin (shard)"
+      annotationSelector: "!sharding.fluxcd.io/role"
     patch: |
       - op: add
         path: /spec/template/spec/containers/0/args/0
-        value: --watch-label-selector=sharding.fluxcd.io/key notin (shard1, shard2)
+        value: --watch-label-selector=!sharding.fluxcd.io/key
 ```
 
 Note how this configuration excludes the sharding keys from the main controllers watch with
-`--watch-label-selector=sharding.fluxcd.io/key notin (shard1, shard2)`. This ensures
+`--watch-label-selector=!sharding.fluxcd.io/key`. This ensures
 that the main controllers will not reconcile any Flux resources labels with the sharding keys.
 
 ### Install and Upgrade shards


### PR DESCRIPTION
This commit updates the docs to use `DoesNotExist` operator (`!`)
for sharding selector.

The current docs use `NotIn` (`notin`) operator, which means that each
time a new shard is added, the root flux deployments needs to be updated
to exclude the new shard label. By using `DoesNotExist` operator, the
root flux deployments can remain unchanged when a new shard is added.
This makes it slightly easier to add and remove shards.
