### PR TITLE
Prevent robots from indexing branch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ preview-build: gen-content prereqs ## Builds a preview build (for e.g. a pull re
 branch-build: gen-content prereqs ## Builds a Git branch (for e.g. development branches).
 	hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \
-		--buildDrafts \
+		--environment branch \
 		--buildFuture \
 		--gc \
 		--minify \

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -2,3 +2,7 @@
 {{ with .Site.Params.algolia_docsearch }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
 {{ end }}
+
+{{ if eq hugo.Environment "branch" }}
+<meta name="robots" content="noindex, nofollow">
+{{ end }}


### PR DESCRIPTION
We don't want archived docs for old Flux versions to be indexed by search engines so that all pages at https://v2-0.docs.fluxcd.io don't turn up in search results.

All Netlify branch builds now lead to all pages being built and deployed to have the `noindex` directive in the page's header.

This PR can be merged immediately as it has no effect on how the site is build and deployed right now. It will only have an effect as soon as we start publishing branch builds for older Flux versions.

I will update the `v2-0` branch from `main` as soon as this PR is merged for the changes to take effect for that branch's deployment.