### PR TITLE
Make import-flux2-assets.sh aware of the desired Flux version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ static/install.sh
 
 # local GH token, used for some scripts
 .gh-token
+
+# build directories
+/bin

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ HUGO_BIND_ADDRESS          ?= 127.0.0.1
 BUILDER_CLI                := docker
 # BUILDER_CLI                := okteto
 LYCHEE_IMAGE_NAME          ?= lycheeverse/lychee:202105190720247e4977
+YQ_VERSION                 ?= v4.34.2
+BRANCH                     ?= main
+
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+BIN_DIR := $(REPO_ROOT)/bin
 
 help:  ## Display this help menu.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -20,11 +26,20 @@ help:  ## Display this help menu.
 
 prereqs:
 	npm install
+	python3 -m pip install -r requirements.txt
 
-gen-content: ## Generates content from external sources.
+.PHONY: yq
+yq: $(BIN_DIR)/yq-$(YQ_VERSION)
+
+$(BIN_DIR)/yq-$(YQ_VERSION):
+	mkdir -p $(BIN_DIR) && wget https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(OS)_$(shell go env GOARCH) -O $(BIN_DIR)/yq-$(YQ_VERSION) && \
+	    chmod +x $(BIN_DIR)/yq-$(YQ_VERSION) && \
+	    cp $(BIN_DIR)/yq-$(YQ_VERSION) $(BIN_DIR)/yq
+
+gen-content: yq ## Generates content from external sources.
 	hack/gen-content.py
 	hack/import-calendar.py
-	hack/import-flux2-assets.sh
+	PATH=$(BIN_DIR):$(PATH) BRANCH=$(BRANCH) hack/import-flux2-assets.sh
 
 serve: gen-content prereqs ## Spawns a development server.
 	hugo server \
@@ -51,7 +66,7 @@ preview-build: gen-content prereqs ## Builds a preview build (for e.g. a pull re
 branch-build: gen-content prereqs ## Builds a Git branch (for e.g. development branches).
 	hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \
-		--environment branch \
+		--buildDrafts \
 		--buildFuture \
 		--gc \
 		--minify \
@@ -63,7 +78,7 @@ docker-preview: docker-serve
 .PHONY: docker-serve
 docker-serve:
 	docker run -v $(shell pwd):/site -p 1313:1313 -it $(SUPPORT_IMAGE_NAME) \
-		make \"MAKEFLAGS=$(MAKEFLAGS)\" serve HUGO_BIND_ADDRESS=0.0.0.0
+		make \"MAKEFLAGS=$(MAKEFLAGS)\" serve HUGO_BIND_ADDRESS=0.0.0.0 GITHUB_TOKEN=$(GITHUB_TOKEN) BRANCH=$(BRANCH)
 
 .PHONY: docker-push docker-push-hugo docker-push-support
 docker-push: docker-push-hugo docker-push-support


### PR DESCRIPTION
Since the website will be built for the 2.0.x minor release, the import script needs to fetch the API docs for the controller versions of the latest 2.0.x Flux release. This change makes the script aware of the desired version (derived from the `BRANCH` environment variable that is set by Netlify).

This change is a subset of the changes implemented in #1577. We cannot simply backport 1577 since the changes in there required some changes to the controller API docs which haven't been released as part of a Flux 2.0.x release, yet.
