### PR TITLE
Add version dropdown and deprecation notice

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -95,15 +95,16 @@ params:
   # Enable Algolia DocSearch
   algolia_docsearch: true
   offlineSearch: false
-  version_menu: "Docs"
-  version: "Flux"
-  url_latest_version: /flux/
+  version_menu: "Versions"
+  version: "2.1"
+  archived_version: false
+  version_menu_pagelinks: true
+  url_latest_version: https://fluxcd.io/flux/
   versions:
-    # Add your release versions here
-    - version: Flux
-      url: /flux
-    - version: Flagger
-      url: /flagger
+    - version: "v2.1"
+      url: https://fluxcd.io
+    - version: "v2.0"
+      url: https://v2-0.docs.fluxcd.io
   logos:
     navbar: flux-horizontal-white.png
     hero: flux-horizontal-color.png
@@ -166,9 +167,9 @@ params:
 
 menus:
   main:
-  - identifier: Project
-    name: Project
-    weight: 20
+  - name: Documentation
+    url: /flux
+    weight: 10
   - name: Code of Conduct
     parent: Project
     url: https://github.com/fluxcd/community/blob/main/CODE_OF_CONDUCT.md
@@ -211,7 +212,9 @@ menus:
   - name: Ecosystem
     url: /ecosystem
     weight: 90
-  - url: https://github.com/fluxcd/flux2
-    name: GitHub
-    pre: "<i class='fab fa-github'></i> "
+  - name: Flagger
+    url: https://flagger.app
     weight: 100
+  - identifier: Project
+    name: Project
+    weight: 110

--- a/layouts/adopters/list.html
+++ b/layouts/adopters/list.html
@@ -3,6 +3,8 @@
 <a class="td-offset-anchor"></a>
 <div class="page td-content container">
 
+    {{ partial "version-banner.html" . }}
+
     {{ .Content | markdownify }}
 
     {{ $projects := $.Site.Data.adopters }}

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -19,6 +19,7 @@
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5 pr-md-4" role="main">
+            {{ partial "version-banner.html" . }}
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
             <a class="td-rss-button" title="RSS" href="{{ .Permalink | safeURL }}" target="_blank" rel="noopener">
               <i class="fa-solid fa-rss" aria-hidden="true"></i>

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -2,6 +2,7 @@
 
 <a class="td-offset-anchor"></a>
 <div class="page td-content container">
+{{ partial "version-banner.html" . }}
 {{ .Content }}
 </div>
 

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,0 +1,14 @@
+<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
+	aria-haspopup="true" aria-expanded="false">
+	{{ .Site.Params.version_menu }}
+</a>
+<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+	{{ $path := "" }}
+	{{ if .Site.Params.version_menu_pagelinks }}
+	{{ $path = .Page.RelPermalink }}
+	{{ end }}
+	<a class="dropdown-item" href="/flux/releases">Release Information</a>
+	{{ range .Site.Params.versions }}
+	<a class="dropdown-item" href="{{ .url }}{{ $path }}">{{ .version }}</a>
+	{{ end }}
+</div>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -35,12 +35,6 @@
   </button>
   <div class="collapse navbar-collapse justify-content-end" id="navbarContent">
     <ul class="navbar-nav mt-2 mt-lg-0">
-      <!-- Move docs selector forward -->
-      {{ if .Site.Params.versions -}}
-      <li class="nav-item dropdown mr-4">
-        {{ partial "navbar-version-selector.html" . -}}
-      </li>
-      {{ end -}}
       {{ $p := . -}}
       {{ range .Site.Menus.main -}}
         {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
@@ -60,25 +54,32 @@
             {{ range .Children  }}
             {{ $childrenurl := urls.Parse .URL }}
             <a class="dropdown-item" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $childrenurl.Host $baseurl.Host }}target="_blank" {{ end }}>{{ .Name }}</a>
-          {{ end }}
+            {{ end }}
          </div>
         </li>
         {{ else }}
-      <li class="nav-item mr-4 mb-2 mb-lg-0">
-        <a {{/**/ -}}
-          class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
-          href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"
-          {{- if ne $url.Host $baseurl.Host }} target="_blank" {{- end -}}
-        >
-            {{- with .Pre }}{{ $pre }}{{ end -}}
-            <span {{- if $active }} class="active" {{- end }}>
-              {{- .Name -}}
-            </span>
-            {{- with .Post }}{{ $post }}{{ end -}}
-        </a>
+        <li class="nav-item mr-4 mb-2 mb-lg-0">
+          <a {{/**/ -}}
+            class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
+            href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}"
+            {{- if ne $url.Host $baseurl.Host }} target="_blank" {{- end -}}
+          >
+              {{- with .Pre }}{{ $pre }}{{ end -}}
+              <span {{- if $active }} class="active" {{- end }}>
+                {{- .Name -}}
+              </span>
+              {{- with .Post }}{{ $post }}{{ end -}}
+          </a>
+        </li>
+        {{ end -}}
+	    {{ end -}}
+
+      {{ if .Site.Params.versions -}}
+      <li class="nav-item dropdown mr-4">
+        {{ partial "navbar-version-selector.html" . -}}
       </li>
       {{ end -}}
-	  {{ end -}}
+
       {{ if (gt (len .Site.Home.Translations) 0) -}}
       <li class="nav-item dropdown mr-4 d-none d-lg-block">
         {{ partial "navbar-lang-selector.html" . -}}

--- a/layouts/partials/version-banner.html
+++ b/layouts/partials/version-banner.html
@@ -1,0 +1,17 @@
+<!-- Check the variable that indicates whether this is an archived doc set.
+  If yes, display a banner. -->
+  {{ if .Site.Params.archived_version }}
+  {{ $color := "primary" }}
+  {{ $latest_version := .Site.Params.url_latest_version }}
+  {{ $current_version := .Site.Params.version }}
+  <div class="pageinfo pageinfo-{{ $color }} deprecation-warning">
+    <h3>You are viewing documentation for Flux version: {{ $current_version }}</h3>
+    {{ with $current_version }}<p>Version {{ . | markdownify }} of the
+      documentation is no longer actively maintained. The site that you are
+      currently viewing is an archived snapshot. 
+      {{ with $latest_version }}For up-to-date documentation, see the 
+        <a href="{{ $latest_version | safeURL }}" target="_blank">latest version</a>.</p>
+      {{ end }}
+    {{ end }}
+  </div>
+{{ end }}

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -3,6 +3,8 @@
 <a class="td-offset-anchor"></a>
 <div class="page td-content container">
 
+    {{ partial "version-banner.html" . }}
+
     {{ .Content | markdownify }}
 
     {{ $resources := $.Site.Data.resources.resources }}


### PR DESCRIPTION
This is a forward-port of #1606 and #1608 in preparation of the 2.1 release.

I took the partial that's part of this change from the Docsy sources and slightly modified it to have the "deprecation-warning" class and some additional text. The original can be found here: https://github.com/google/docsy/blob/3f3172a190ac9b24aa5b9c695f62c3fee8273ac2/layouts/partials/version-banner.html

This commit also moves the link to Flagger into the top navbar so that we can actually use the version drop-down for listing Flux versions. A dedicated "Documentation" link in the top navbar now directs users to the Flux documentation.

The link to GitHub is also removed to make the navbar be closer to the one at kubernetes.io.
