### PR TITLE
Fix GHA cosign example

### DIFF
--- a/content/en/flux/flux-gh-action.md
+++ b/content/en/flux/flux-gh-action.md
@@ -172,7 +172,8 @@ jobs:
           $OCI_REPO:$(git rev-parse --short HEAD) \
           --path="./manifests" \
           --source="$(git config --get remote.origin.url)" \
-          --revision="$(git branch --show-current)@sha1:$(git rev-parse HEAD)" |\
+          --revision="$(git branch --show-current)@sha1:$(git rev-parse HEAD)" \
+          --output=json | \
           jq -r '. | .repository + "@" + .digest')
 
           cosign sign --yes $digest_url


### PR DESCRIPTION
Add missing `--output=json` flag.