### PR TITLE
Add Somtochi to the maintainers list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,6 +8,7 @@ Hidde Beydals, Weaveworks <hidde@weave.works> (github: @hiddeco, slack: hidde)
 Scott Rigby, Independent <scott@r6by.com> (github: @scottrigby, slack: scottrigby)
 Stefan Prodan, Weaveworks <stefan@weave.works> (github: @stefanprodan, slack: stefanprodan)
 Kingdon Barrett, Weaveworks <kingdon@weave.works> (github: @kingdonb, slack: Kingdon B)
+Somtochi Onyekwere, Weaveworks <somtochi@weave.works> (github: @somtochiama, slack: somtochiama)
 
 Retired maintainers:
 


### PR DESCRIPTION
@stefanprodan @kingdonb @/hidde @scottrigby

I volunteer as a maintainer for fluxcd/website.

I reviewed the maintainer [community roles doc](https://github.com/fluxcd/community/blob/main/community-roles.md#maintainer) which is quite familiar to me now, and it looks like I meet all of the criteria.

For easy reference, my history as a contributor here:
PRs I contributed: https://github.com/fluxcd/website/pulls/somtochiama.

I have also taken up the responsibility of writing the Flux announcement blog post for each Flux release.
Thank you.