### PR TITLE
Fix link to bootstrap customization guide

### DIFF
--- a/content/en/flux/components/helm/options.md
+++ b/content/en/flux/components/helm/options.md
@@ -6,7 +6,7 @@ weight: 1
 ---
 
 To customise the controller options at install time,
-please see the [bootstrap cheatsheet](../../cheatsheets/bootstrap.md).
+please see the [bootstrap customization guide](/flux/installation/configuration/boostrap-customization/).
 
 ## Flags
 

--- a/content/en/flux/components/image/options.md
+++ b/content/en/flux/components/image/options.md
@@ -6,7 +6,7 @@ weight: 1
 ---
 
 To customise the controller options at install time,
-please see the [bootstrap cheatsheet](../../cheatsheets/bootstrap.md).
+please see the [bootstrap customization guide](/flux/installation/configuration/boostrap-customization/).
 
 ## Image automation flags
 

--- a/content/en/flux/components/kustomize/options.md
+++ b/content/en/flux/components/kustomize/options.md
@@ -6,7 +6,7 @@ weight: 1
 ---
 
 To customise the controller options at install time,
-please see the [bootstrap cheatsheet](../../cheatsheets/bootstrap.md).
+please see the [bootstrap customization guide](/flux/installation/configuration/boostrap-customization/).
 
 ## Flags
 

--- a/content/en/flux/components/notification/options.md
+++ b/content/en/flux/components/notification/options.md
@@ -6,7 +6,7 @@ weight: 1
 ---
 
 To customise the controller options at install time,
-please see the [bootstrap cheatsheet](../../cheatsheets/bootstrap.md).
+please see the [bootstrap customization guide](/flux/installation/configuration/boostrap-customization/).
 
 ## Flags
 

--- a/content/en/flux/components/source/options.md
+++ b/content/en/flux/components/source/options.md
@@ -6,7 +6,7 @@ weight: 1
 ---
 
 To customise the controller options at install time,
-please see the [bootstrap cheatsheet](../../cheatsheets/bootstrap.md).
+please see the [bootstrap customization guide](/flux/installation/configuration/boostrap-customization/).
 
 ## Flags
 


### PR DESCRIPTION
The re-organization that happened as part of https://github.com/fluxcd/website/pull/1573 removed this page.

PR https://github.com/fluxcd/website/pull/1573 added a redirect for /flux/cheatsheets/bootstrap but in this case it's better to specifically link directly to the customization guide instead of the general configuration page.

closes https://github.com/fluxcd/website/issues/1658