### PR TITLE
Add a note for image automation to upgrade guide

### DIFF
--- a/content/en/flux/installation/upgrade.md
+++ b/content/en/flux/installation/upgrade.md
@@ -43,6 +43,16 @@ git add -A && git commit -m "Update $(flux -v) on my-cluster"
 git push
 ```
 
+If you've enabled extra Flux components at bootstrap,
+like those required for the [image automation feature](/flux/guides/image-update/).
+Ensure to include these components when generating the components manifest:
+
+```shell
+flux install \
+--components-extra image-reflector-controller,image-automation-controller \
+--export > ./clusters/my-cluster/flux-system/gotk-components.yaml
+```
+
 Wait for Flux to detect the changes or, tell it to do the upgrade immediately with:
 
 ```sh


### PR DESCRIPTION
Add example on how to upgrade when the Flux image automation feature has been enabled at bootstrap.

Closes: https://github.com/fluxcd/flux2/issues/4259