### PR TITLE
Add safeURL to fix "next event" partial

### DIFF
--- a/layouts/shortcodes/home/next_event.html
+++ b/layouts/shortcodes/home/next_event.html
@@ -3,6 +3,9 @@
 
 <p class="next-event">
 {{ range first 1 $.Site.Data.calendar }}
-📆 Next event: <a href="{{ .where }}">{{ .date }} {{ .time }} UTC: {{ .label }}</a>
+📆 Next event: {{ .date }} {{ .time }} UTC:<br/>
+{{ .label }}<br/>
+Where: {{ safeURL .where }}
+
 {{ end }}
 </p>


### PR DESCRIPTION
Fix #1671

There is a fully-formed link in the `.where` of each calendar event in the generated yaml, but hugo sanitizes it.

We were expecting a bare URL here anyway, instead of a link. Rework the shortcode slightly so it behaves.