### PR TITLE
[v2-0] Bump actions/checkout from 4.0.0 to 4.1.0

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged && (github.event_name != 'labeled' || startsWith('backport:', github.event.label.name))
     steps:
       - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.5.4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.state == 'closed' && github.event.pull_request.merged && (github.event_name != 'labeled' || startsWith('backport:', github.event.label.name))
     steps:
       - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.5.4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.5.4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs

--- a/.github/workflows/build-push-hugo-image.yml
+++ b/.github/workflows/build-push-hugo-image.yml
@@ -30,7 +30,7 @@ jobs:
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
       -
         name: Checkout repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       -
         name: Set repo_owner variable
         run: make --silent print-repo-owner >> $GITHUB_ENV
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
       -
         name: Checkout repo
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       -
         name: Set repo_owner variable
         run: make --silent print-repo-owner >> $GITHUB_ENV

--- a/.github/workflows/build-push-hugo-image.yml
+++ b/.github/workflows/build-push-hugo-image.yml
@@ -30,7 +30,7 @@ jobs:
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
       -
         name: Checkout repo
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       -
         name: Set repo_owner variable
         run: make --silent print-repo-owner >> $GITHUB_ENV
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.DOCKER_FLUXCD_PASSWORD }}
       -
         name: Checkout repo
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       -
         name: Set repo_owner variable
         run: make --silent print-repo-owner >> $GITHUB_ENV

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.5.4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.5.4
       - uses: EndBug/label-sync@da00f2c11fdb78e4fae44adac2fdd713778ea3e8 # v2.3.2
         with:
           # Configuration file

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.5.4
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - uses: EndBug/label-sync@da00f2c11fdb78e4fae44adac2fdd713778ea3e8 # v2.3.2
         with:
           # Configuration file

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -10,7 +10,7 @@ jobs:
   updateContributors:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -10,7 +10,7 @@ jobs:
   updateContributors:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Automated backport to v2-0, triggered by a label in https://github.com/fluxcd/website/pull/1670.

I had to manually create this PR because of an issue with permissions of the bot token.