### PR TITLE
[v2-0] update hugo to v0.119.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "make production-build"
 
 [build.environment]
-  HUGO_VERSION = "0.117.0"
+  HUGO_VERSION = "0.119.0"
   NODE_VERSION = "16"
   GO_VERSION = "1.18"
 


### PR DESCRIPTION
Automated backport to v2-0, triggered by a label in #1675.

I had to manually create this PR because of a conflict in the file.