### PR TITLE
docs: replace `patchesStrategicMerge` with `patches`

### DIFF
--- a/content/en/flux/guides/mozilla-sops.md
+++ b/content/en/flux/guides/mozilla-sops.md
@@ -357,6 +357,7 @@ az keyvault set-policy --name ${VAULT_NAME} --object-id ${IDENTITY_ID} --key-per
 ```
 
 Create an `AzureIdentity` object that references the identity created above:
+
 ```yaml
 ---
 apiVersion: aadpodidentity.k8s.io/v1
@@ -371,6 +372,7 @@ spec:
 ```
 
 Create an `AzureIdentityBinding` object that binds pods with a specific selector with the `AzureIdentity` created above.
+
 ```yaml
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentityBinding
@@ -437,6 +439,7 @@ to get started committing encrypted files to your Git Repository or other Source
 [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#before_you_begin) has to be enabled on the cluster and on the node pools.
 
 {{% alert color="info" title="Terraform" %}} If you like to use terraform instead of gcloud, you will need the following resources from the `hashicorp/google` provider:
+
 * create GCP service account: "google_service_account"
 * add role KMS encrypter/decrypter: "google_project_iam_member"
 * bind GCP SA to Flux kustomize-controller SA: "google_service_account_iam_binding" {{% /alert %}}
@@ -476,16 +479,19 @@ gcloud iam service-accounts add-iam-policy-binding \
 3. [Customize your Flux Manifests](/flux/installation/) and patch the kustomize-controller service account with the proper annotation so that Workload Identity knows the relationship between the gcp service account and the k8s service account.
 
 ``` yaml
- ### add this patch to annotate service account if you are using Workload identity
-patchesStrategicMerge:
-- |-
-  apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: kustomize-controller
-    namespace: flux-system
-    annotations:
-      iam.gke.io/gcp-service-account: <SERVICE_ACCOUNT_ID>@<PROJECT_ID>.iam.gserviceaccount.com
+### add this patch to annotate service account if you are using Workload identity
+patches:
+  - patch: |
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kustomize-controller
+        namespace: flux-system
+        annotations:
+          iam.gke.io/gcp-service-account: <SERVICE_ACCOUNT_ID>@<PROJECT_ID>.iam.gserviceaccount.com
+    target:
+      kind: ServiceAccount
+      name: kustomize-controller
 ```
 
 If you didn't bootstrap Flux, you can use this instead

--- a/content/en/flux/guides/repository-structure.md
+++ b/content/en/flux/guides/repository-structure.md
@@ -171,13 +171,17 @@ spec:
     kind: GitRepository
     name: app
   path: ./deploy/manifests
-  patchesStrategicMerge:
-    - apiVersion: apps/v1
-      kind: Deployment
-      metadata:
+  patches:
+    - patch: |
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: app
+        spec:
+          replicas: 2
+      target:
+        kind: Deployment
         name: app
-      spec:
-        replicas: 2
 ```
 
 App repository Kustomize overlays example:


### PR DESCRIPTION
Hi @stefanprodan @hiddeco!
I am addressing this PR #1545

> **NOTE:** I've tested everything on my side using `kustomize build` command

There is a point I'd like to discuss. In `cron-job-image-auth.md` we were using `patchesStrategicMerge` that allows us to apply patches to multiple resources within one patch file. When I tried to do the same with inline patches, I wasn't able because it's not supported in Kustomize version earlier than 5.2.1. Please check the [changelog file](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.2.1) for a [PR](https://github.com/kubernetes-sigs/kustomize/pull/5194) that adds a support for this. When I upgrade to the latest version I was able to do it.
So I'd like to clarify if the latest version of FluxCD supports the latest stable version of Kustomize?

Also some small fixes of these markdown violations:

* MD014/commands-show-output: Dollar signs used before commands without showing output
* MD031/blanks-around-fences: Fenced code blocks should be surrounded by blank lines
* MD032/blanks-around-lists: Lists should be surrounded by blank lines
