### PR TITLE
Add Tchibo to flagger adopters

### DIFF
--- a/data/adopters/2-flagger.yaml
+++ b/data/adopters/2-flagger.yaml
@@ -85,3 +85,6 @@ adopters:
     - name: EcoVadis
       url: https://ecovadis.com/
       logo: logos/ecovadis.png
+    - name: Tchibo
+      url: https://tchibo.de
+      logo: logos/tchibo.png


### PR DESCRIPTION
Tchibo wants to provide its developers progressive delivery tooling for its internal developer platform. As Flux is already in use, Flagger perfectly complements the GitOps approach here.
An example application implementation, which covers several use cases, got already provided for internal usage for our developers.