### PR TITLE
Update cosign verify certificate identity regexp

### DIFF
--- a/content/en/flux/security/_index.md
+++ b/content/en/flux/security/_index.md
@@ -33,7 +33,7 @@ install [cosign](https://docs.sigstore.dev/cosign/installation/) v2 and run:
 
 ```console
 $ cosign verify ghcr.io/fluxcd/source-controller:v1.0.0 \
-  --certificate-identity-regexp=https://github\\.com/fluxcd/ \
+  --certificate-identity-regexp=^https://github\\.com/fluxcd/.*$ \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com 
 
 Verification for ghcr.io/fluxcd/source-controller:v1.0.0 --

--- a/content/en/flux/security/_index.md
+++ b/content/en/flux/security/_index.md
@@ -33,7 +33,7 @@ install [cosign](https://docs.sigstore.dev/cosign/installation/) v2 and run:
 
 ```console
 $ cosign verify ghcr.io/fluxcd/source-controller:v1.0.0 \
-  --certificate-identity-regexp=https://github.com/fluxcd \
+  --certificate-identity-regexp=https://github\\.com/fluxcd/ \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com 
 
 Verification for ghcr.io/fluxcd/source-controller:v1.0.0 --


### PR DESCRIPTION
Small update to the cosign verify command.

- ensure the image is produced by https://github.com/fluxcd and not https://github.com/fluxcd-something-else
- escape the wildcard dot in the domain name. It's unlikely to be an issue but it's a bit safer by default when validating hostnames with a regexp.