### PR TITLE
Fix bad link in get-started.md

### DIFF
--- a/content/en/flux/get-started.md
+++ b/content/en/flux/get-started.md
@@ -59,7 +59,7 @@ The output is similar to:
 
 ## Install Flux onto your cluster
 
-For information on how to bootstrap using a GitHub org, Gitlab and other git providers, see [Installation](installation.md).
+For information on how to bootstrap using a GitHub org, Gitlab and other git providers, see [Bootstrapping](/flux/installation/bootstrap/).
 
 Run the bootstrap command:
 


### PR DESCRIPTION
The disambiguation page is "Bootstrap" now

We can merge this straight away, or wait until I've reviewed all the links on this page. I think we're trying to avoid relative links now generally, so I'll change all of the relative links on this page into absolute paths even if they're not currently bad links.