### PR TITLE
Update HelmRelease, Alerts and Providers to Flux v2.2.0

### DIFF
--- a/content/en/flagger/install/flagger-install-with-flux.md
+++ b/content/en/flagger/install/flagger-install-with-flux.md
@@ -56,7 +56,7 @@ Define a Flux `HelmRelease` that verifies and installs Flagger's latest version 
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: flagger

--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -106,7 +106,7 @@ spec:
   type: oci
   url: oci://ghcr.io/stefanprodan/charts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -452,7 +452,7 @@ spec:
   url: oci://<registry-host>/<org>/charts
   type: oci
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: <app-name>
@@ -683,7 +683,7 @@ spec:
 Then add the policy marker to the `HelmRelease` manifest in Git:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -479,7 +479,7 @@ please see the [HelmChart documentation](/flux/components/source/helmcharts/#ver
 Configure alerting for when new artifacts are pulled and reconciled:
 
 ```yaml
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: podinfo

--- a/content/en/flux/cheatsheets/troubleshooting.md
+++ b/content/en/flux/cheatsheets/troubleshooting.md
@@ -219,7 +219,7 @@ Deployment is not ready: default/podinfo. 0 out of 1 expected pods are ready
 To inspect the failing resources, you can disable the health checks with:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
  name: podinfo

--- a/content/en/flux/faq.md
+++ b/content/en/flux/faq.md
@@ -331,7 +331,7 @@ spec:
   url: oci://ghcr.io/kyverno/charts
   type: oci
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kyverno
@@ -450,7 +450,7 @@ spec:
   interval: 30m
   url: https://charts.bitnami.com/bitnami
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: metrics-server
@@ -480,7 +480,7 @@ when Bitnami publishes a new version of the metrics-server chart.
 Lets assume we have a common `HelmRelease` definition we use as a base and we
 we need to further customize it e.g per cluster, tenant, environment and so on:
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -534,7 +534,7 @@ spec:
 #### Using Kustomize variable substitution
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/flux-e2e.md
+++ b/content/en/flux/flux-e2e.md
@@ -621,7 +621,7 @@ The health checking feature is called [Health Checks][] in the Flux Kustomizatio
 [Helm Use Case]: /flux/use-cases/helm/
 [HelmRepository API]: /flux/components/source/helmrepositories/
 [HelmChart API]: /flux/components/source/helmcharts/
-[HelmChartTemplate.spec.reconcileStrategy]: /flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate
+[HelmChartTemplate.spec.reconcileStrategy]: /flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate
 [Setup Notifications]: /flux/guides/notifications/
 [Alert API]: /flux/components/notification/alert/
 [Event API]: /flux/components/notification/event/

--- a/content/en/flux/gitops-toolkit/packages.md
+++ b/content/en/flux/gitops-toolkit/packages.md
@@ -81,14 +81,14 @@ go get github.com/fluxcd/helm-controller/api
 Import package
 
 ```go
-import helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+import helmv2 "github.com/fluxcd/helm-controller/api/v2beta2"
 ```
 
 API Types
 
 | Name                                              | Version |
 |---------------------------------------------------|---------|
-| [HelmRelease](../components/helm/helmreleases.md) | v2beta1 |
+| [HelmRelease](../components/helm/helmreleases.md) | v2beta2 |
 
 ### notification.toolkit.fluxcd.io
 
@@ -166,7 +166,7 @@ import (
   ctrl "sigs.k8s.io/controller-runtime"
   "sigs.k8s.io/controller-runtime/pkg/client"
 
-  helmv2 "github.com/fluxcd/helm-controller/api/v2beta1"
+  helmv2 "github.com/fluxcd/helm-controller/api/v2beta2"
   apimeta "github.com/fluxcd/pkg/apis/meta"
   sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 )

--- a/content/en/flux/gitops-toolkit/packages.md
+++ b/content/en/flux/gitops-toolkit/packages.md
@@ -101,7 +101,7 @@ go get github.com/fluxcd/notification-controller/api
 Import package
 
 ```go
-import notificationv1b2 "github.com/fluxcd/notification-controller/api/v1beta2"
+import notificationv1b3 "github.com/fluxcd/notification-controller/api/v1beta3"
 ```
 
 and for `Receiver` objects:
@@ -114,9 +114,9 @@ API Types
 
 | Name                                               | Version |
 |----------------------------------------------------|---------|
-| [Receiver](../components/notification/receivers.md)| v1      |
-| [Provider](../components/notification/providers.md) | v1beta2 |
-| [Alert](../components/notification/alerts.md)       | v1beta2 |
+| [Receiver](../components/notification/receiver.md) | v1      |
+| [Provider](../components/notification/provider.md) | v1beta3 |
+| [Alert](../components/notification/alert.md)       | v1beta3 |
 
 ### image.toolkit.fluxcd.io
 

--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -552,7 +552,7 @@ the `flux-system` to start receiving notifications about the Helm
 release:
 
 ```yaml
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: helm-podinfo

--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -212,7 +212,7 @@ With the chart source created, define a new `HelmRelease` to release
 the Helm chart:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -327,7 +327,7 @@ nameReference:
 Create a `HelmRelease` definition that references a `ConfigMap`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -368,7 +368,7 @@ When [kustomize-controller](../components/kustomize/_index.md) reconciles the ab
 a unique name of the `ConfigMap` every time `my-values.yaml` content is updated in Git:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -408,7 +408,7 @@ nameReference:
 Create a `HelmRelease` definition that references a `Secret`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -511,7 +511,7 @@ in the context then they can recover decrypted values using `helm get values`.
 It is possible to replace the `values.yaml` with a different file present inside the Helm chart.
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mongodb
@@ -644,7 +644,7 @@ It is possible create a new chart artifact when a Source's revision has changed,
 `version` in the Chart.yml has not been bumped, for `GitRepository` and `Bucket` sources.
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v2beta1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmChart
 metadata:
   name: podinfo

--- a/content/en/flux/guides/image-update.md
+++ b/content/en/flux/guides/image-update.md
@@ -404,7 +404,7 @@ Here are some examples of using this marker in a variety of Kubernetes resources
 `HelmRelease` example:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/guides/repository-structure.md
+++ b/content/en/flux/guides/repository-structure.md
@@ -237,7 +237,7 @@ metadata:
 spec:
   url: https://<host>/<org>/charts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: app

--- a/content/en/flux/guides/sealed-secrets.md
+++ b/content/en/flux/guides/sealed-secrets.md
@@ -135,7 +135,7 @@ spec:
 Helm release manifest:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sealed-secrets

--- a/content/en/flux/installation/configuration/sharding.md
+++ b/content/en/flux/installation/configuration/sharding.md
@@ -255,7 +255,7 @@ spec:
   type: oci
   url: oci://ghcr.io/stefanprodan/charts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -309,7 +309,7 @@ spec:
     - target:
         kind: HelmRelease
       patch: |
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2beta2
         kind: HelmRelease
         metadata:
           name: all

--- a/content/en/flux/migration/helm-operator-migration.md
+++ b/content/en/flux/migration/helm-operator-migration.md
@@ -34,7 +34,7 @@ From a technical perspective, this also means less overhead, as the resources ma
 
 Due to the Helm Controller becoming part of the extensive set of controller components Flux now has, the Custom Resource group domain has changed from `helm.fluxcd.io` to `helm.toolkit.fluxcd.io`.
 
-Together with the new API version (`v2beta1` at time of writing), the full `apiVersion` you use in your YAML document becomes `helm.toolkit.fluxcd.io/v2beta1`.
+Together with the new API version (`v2beta2` at time of writing), the full `apiVersion` you use in your YAML document becomes `helm.toolkit.fluxcd.io/v2beta2`.
 
 ### The API specification changed (quite a lot), for the better
 
@@ -76,7 +76,7 @@ Getting similar behaviour is still possible [using a workaround that makes use o
 
 There was a long outstanding request for the Helm Operator to support merging single values at a given path.
 
-With the Helm Controller this now possible by defining a [`targetPath` in the `ValuesReference`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.ValuesReference), which supports the same formatting as you would supply as an argument to the `helm` binary using `--set [path]=[value]`. In addition to this, the referred value can contain the same value formats (e.g. `{a,b,c}` for a list). You can read more about the available formats and limitations in the [Helm documentation](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set).
+With the Helm Controller this now possible by defining a [`targetPath` in the `ValuesReference`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.ValuesReference), which supports the same formatting as you would supply as an argument to the `helm` binary using `--set [path]=[value]`. In addition to this, the referred value can contain the same value formats (e.g. `{a,b,c}` for a list). You can read more about the available formats and limitations in the [Helm documentation](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set).
 
 ### Support added for depends-on relationships
 
@@ -131,7 +131,7 @@ $ flux create helmrelease podinfo \
     --chart-version=">4.0.0" \
     --export
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -220,11 +220,11 @@ spec:
     name: my-repository-creds
 ```
 
-In the `HelmRelease`, you then use a reference to the `HelmRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate)):
+In the `HelmRelease`, you then use a reference to the `HelmRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate)):
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -322,11 +322,11 @@ spec:
     name: my-repository-creds
 ```
 
-In the `HelmRelease`, you then use a reference to the `GitRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.HelmChartTemplate)):
+In the `HelmRelease`, you then use a reference to the `GitRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate)):
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -356,7 +356,7 @@ Inlined values (defined in the `spec.values` of the `HelmRelease`) still work as
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -404,11 +404,11 @@ spec:
       optional: true
 ```
 
-In the new API spec the individual `configMapKeyRef` and `secretKeyRef` objects are bundled into a single [`ValuesReference`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.ValuesReference) which [does no longer allow refering to resources in other namespaces](#values-from-external-source-references-urls-are-no-longer-supported):
+In the new API spec the individual `configMapKeyRef` and `secretKeyRef` objects are bundled into a single [`ValuesReference`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.ValuesReference) which [does no longer allow refering to resources in other namespaces](#values-from-external-source-references-urls-are-no-longer-supported):
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -452,7 +452,7 @@ With the Helm Controller, this declaration has moved to the `spec.chart.spec`, a
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -572,7 +572,7 @@ You can now refer to the `my-external-values` `ConfigMap` resource in your `Helm
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -588,7 +588,7 @@ spec:
 
 With the Helm Operator the release options used to be configured in the `spec` of the `HelmRelease` and applied to both Helm install and upgrade actions.
 
-This has changed for the Helm Controller, where some defaults can be defined in the [`spec`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.HelmReleaseSpec), but specific action configurations and overwrites for the defaults can be defined in the [`spec.install`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Install), [`spec.upgrade`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Upgrade) and [`spec.test`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Test) sections of the `HelmRelease`.
+This has changed for the Helm Controller, where some defaults can be defined in the [`spec`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec), but specific action configurations and overwrites for the defaults can be defined in the [`spec.install`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Install), [`spec.upgrade`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Upgrade) and [`spec.test`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Test) sections of the `HelmRelease`.
 
 ### Defining a rollback / uninstall configuration
 
@@ -613,14 +613,14 @@ spec:
     timeout: 300
 ```
 
-The Helm Controller offers an extensive set of configuration options to remediate when a Helm release fails, using [`spec.install.remediation`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.InstallRemediation), [`spec.upgrade.remediation`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.UpgradeRemediation), [`spec.rollback`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Rollback) and [`spec.uninstall`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Uninstall). Some of the new features include the option to remediate with an uninstall after an upgrade failure, and the option to keep a failed release for debugging purposes when it has run out of retries.
+The Helm Controller offers an extensive set of configuration options to remediate when a Helm release fails, using [`spec.install.remediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.InstallRemediation), [`spec.upgrade.remediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation), [`spec.rollback`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Rollback) and [`spec.uninstall`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Uninstall). Some of the new features include the option to remediate with an uninstall after an upgrade failure, and the option to keep a failed release for debugging purposes when it has run out of retries.
 
 #### Automated uninstalls
 
-The configuration below mimics the uninstall behavior of the Helm Operator (for all available fields, consult the [`InstallRemediation`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.InstallRemediation) and [`Uninstall`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Uninstall) API references):
+The configuration below mimics the uninstall behavior of the Helm Operator (for all available fields, consult the [`InstallRemediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.InstallRemediation) and [`Uninstall`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Uninstall) API references):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -643,10 +643,10 @@ spec:
 
 #### Automated rollbacks
 
-The configuration below shows an automated rollback configuration that equals [the configuration for the Helm Operator showed above](#defining-a-rollback--uninstall-configuration) (for all available fields, consult the [`UpgradeRemediation`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.UpgradeRemediation) and [`Rollback`](/flux/components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Rollback) API references):
+The configuration below shows an automated rollback configuration that equals [the configuration for the Helm Operator showed above](#defining-a-rollback--uninstall-configuration) (for all available fields, consult the [`UpgradeRemediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation) and [`Rollback`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Rollback) API references):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -726,7 +726,7 @@ spec:
   interval: 10m
   url: https://stefanprodan.github.io/podinfo
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/monitoring/alerts.md
+++ b/content/en/flux/monitoring/alerts.md
@@ -34,7 +34,7 @@ kubectl -n flagger-system create secret generic slack-bot-token \
 Create a notification provider for Slack by referencing the above secret:
 
 ```yaml
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: slack-bot
@@ -57,7 +57,7 @@ For a complete list please see the [Provider `.spec.type` documentation](/flux/c
 Create an alert definition for all repositories and kustomizations:
 
 ```yaml
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: on-call-webapp
@@ -199,7 +199,7 @@ The only caveat being that the provider address needs to point to the same
 git repository as the event source originates from.
 
 ```yaml
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: flux-system
@@ -210,7 +210,7 @@ spec:
   secretRef:
     name: github
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: podinfo
@@ -306,7 +306,7 @@ To display the Flux notifications on Grafana dashboards
 you can configure Flux to push events to Grafana annotations API:
 
 ```yaml
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: grafana
@@ -320,7 +320,7 @@ spec:
       name: '*'
       namespace: flux-system
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: grafana

--- a/content/en/flux/monitoring/custom-metrics.md
+++ b/content/en/flux/monitoring/custom-metrics.md
@@ -82,7 +82,7 @@ customResourceState:
       resources:
         - groupVersionKind:
             group: helm.toolkit.fluxcd.io
-            version: "v2beta1"
+            version: "v2beta2"
             kind: HelmRelease
           metricNamePrefix: gotk
           metrics:
@@ -117,12 +117,12 @@ will be exported for HelmReleases.
 ```
 # HELP gotk_resource_info The current state of a GitOps Toolkit resource.
 # TYPE gotk_resource_info info
-gotk_resource_info{customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta1",exported_namespace="monitoring",name="kube-prometheus-stack",ready="True"} 1
-gotk_resource_info{customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta1",exported_namespace="monitoring",name="loki-stack",ready="True"} 1
+gotk_resource_info{customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta2",exported_namespace="monitoring",name="kube-prometheus-stack",ready="True"} 1
+gotk_resource_info{customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta2",exported_namespace="monitoring",name="loki-stack",ready="True"} 1
 # HELP gotk_helmrelease_version_info The version information of helm release resource.
 # TYPE gotk_helmrelease_version_info info
-gotk_helmrelease_version_info{chartName="kube-prometheus-stack",customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta1",exported_namespace="monitoring",name="kube-prometheus-stack",version="48.3.1"} 1
-gotk_helmrelease_version_info{chartName="loki-stack",customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta1",exported_namespace="monitoring",name="loki-stack",version="2.9.11"} 1
+gotk_helmrelease_version_info{chartName="kube-prometheus-stack",customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta2",exported_namespace="monitoring",name="kube-prometheus-stack",version="48.3.1"} 1
+gotk_helmrelease_version_info{chartName="loki-stack",customresource_group="helm.toolkit.fluxcd.io",customresource_kind="HelmRelease",customresource_version="v2beta2",exported_namespace="monitoring",name="loki-stack",version="2.9.11"} 1
 ```
 
 ## Adding custom metric labels

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -163,7 +163,7 @@ it performs a Helm release upgrade.
 Example of `clusters/staging/apps/demo-github.yaml`:
 
 ```yaml
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: github
@@ -174,7 +174,7 @@ spec:
   secretRef:
     name: github-token
 ---
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   name: demo-dispatch

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -37,7 +37,7 @@ and it will automatically upgrade the Helm release to the latest chart version b
 Example of `clusters/staging/apps/demo.yaml`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: demo
@@ -65,7 +65,7 @@ update in Git by GitHub Actions based on the Flux events.
 Example of `clusters/production/apps/demo.yaml`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: demo

--- a/content/en/flux/use-cases/helm.md
+++ b/content/en/flux/use-cases/helm.md
@@ -78,7 +78,7 @@ spec:
 
 ```yaml
 # /flux/boot/traefik/helmrelease.yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-traefik
@@ -177,10 +177,10 @@ documentation.
 ## Automatic Uninstalls and Rollback
 
 The Helm Controller offers an extensive set of configuration options to remediate when a Helm release fails,
-using [spec.install.remediation](../components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.InstallRemediation),
-[spec.upgrade.remediation](../components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.UpgradeRemediation),
-[spec.rollback](../components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Rollback)
-and [spec.uninstall](../components/helm/api/v2beta1#helm.toolkit.fluxcd.io/v2beta1.Uninstall).
+using [spec.install.remediation](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.InstallRemediation),
+[spec.upgrade.remediation](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation),
+[spec.rollback](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Rollback)
+and [spec.uninstall](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Uninstall).
 Features include the option to remediate with an uninstall after an upgrade failure,
 and the option to keep a failed release for debugging purposes when it has run out of retries.
 
@@ -188,7 +188,7 @@ Here is an example for configuring automated uninstalls (for all available field
 consult the `InstallRemediation` and `Uninstall` API references linked above):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -213,7 +213,7 @@ Here is an example of automated rollback configuration (for all available fields
 consult the `UpgradeRemediation` and `Rollback` API references linked above):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-release

--- a/content/en/flux/use-cases/karmada.md
+++ b/content/en/flux/use-cases/karmada.md
@@ -83,7 +83,7 @@ spec:
   interval: 1m
   url: https://stefanprodan.github.io/podinfo  
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -122,7 +122,7 @@ metadata:
   name: helm-release
 spec:
   resourceSelectors:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta2
       kind: HelmRelease
       name: podinfo
   placement:
@@ -179,7 +179,7 @@ metadata:
   namespace: default
 spec:
   resourceSelectors:
-  - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+  - apiVersion: helm.toolkit.fluxcd.io/v2beta2
     kind: HelmRelease
     name: podinfo
   overrideRules:


### PR DESCRIPTION
Notification-controller is introducing v1beta3 APIs for Alerts and Providers, refer https://github.com/fluxcd/notification-controller/pull/540. Helm-controller is introducing v2beta2 API for HelmRelease. Update all the references to those APIs to use the new version.

Depends on https://github.com/fluxcd/notification-controller/pull/540 and https://github.com/fluxcd/helm-controller/pull/738.