### PR TITLE
(Pre-)Release v2.2.0 Blog

### DIFF
--- a/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
+++ b/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
@@ -1,0 +1,24 @@
+---
+author: kingdonb
+date: 2023-12-07 00:00:00+00:00
+title: Flux v2.2 release is just around the corner!
+description: "Flux v2.2.0: Major Helm improvements!"
+url: /blog/2023/12/flux-v2-2-release-around-the-corner/
+tags: [announcement]
+resources:
+- src: "**.{png,jpg}"
+  title: "Image #:counter"
+---
+
+Now that Flux has reached General Availability, there are planned 3 minor releases per year. So, the maintainer team has been hard at work to create this Flux v2.2.0 release, which is slated to come out next week! Keep your eye out!
+
+While this next release addresses [hundreds of issues and has many improvements](https://github.com/fluxcd/flux2/issues/4410) that will be covered in more detail by a follow-up blog post, we want to highlight one crowning achievement of the next release: Flux helm-controller's reconciliation model has undergone a significant overhaul, this is the one we've all been waiting for!
+
+We hope many Flux users will rejoice in the improvements of the updated helm-controller, and that you'll all update to the latest release. This will help, in particular, with the issue of how the automatic recovery of releases could occasionally get stuck in a pending state. In addition, the latest release improves the observability of the release status by reflecting more detailed historic information in the status of the HelmRelease object.
+
+Lastly, the new release introduces the ability to enable drift detection on a per-object basis. This includes the option to ignore drift in specific fields using Kustomize-like target selectors and JSON pointer paths, which helps to reduce the noise and prevent upgrades from infinitely cycling. Helm Drift detection and correction also is no longer experimental since this release. Opt-in through `HelmRelease.spec.driftDetection` in the `v2beta2` API.
+
+There's much more in the upcoming Flux v2.2.0 release such as updates and improvements to Flux source-controller, image-reflector-controller, kustomize-controller, notification-controller, and the Flux CLI!
+
+If you get stuck with anything or have feedback, we've got a Slack channel, GitHub discussions, and many other ways to get help from the Flux maintainers, contributors, and community: [fluxcd.io/support/](https://fluxcd.io/support/)
+

--- a/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
+++ b/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
@@ -12,11 +12,27 @@ resources:
 
 Now that Flux has reached General Availability, there are planned 3 minor releases per year. So, the maintainer team has been hard at work to create this Flux v2.2.0 release, which is slated to come out next week! Keep your eye out!
 
-While this next release addresses [hundreds of issues and has many improvements](https://github.com/fluxcd/flux2/issues/4410) that will be covered in more detail by a follow-up blog post, we want to highlight one crowning achievement of the next release: Flux helm-controller's reconciliation model has undergone a significant overhaul, this is the one we've all been waiting for!
+While this next release addresses hundreds of issues and has many improvements that will be covered in more detail by a follow-up blog post, we want to highlight one crowning achievement of the next release: Flux helm-controller's reconciliation model has undergone a significant overhaul, this is the one we've all been waiting for!
 
-We hope many Flux users will rejoice in the improvements of the updated helm-controller, and that you'll all update to the latest release. This will help, in particular, with the issue of how the automatic recovery of releases could occasionally get stuck in a pending state. In addition, the latest release improves the observability of the release status by reflecting more detailed historic information in the status of the HelmRelease object.
+We hope many Flux users will rejoice in the improvements of the updated helm-controller, and that you'll all update to the latest release. This will help, in particular, with the issue of how the automatic recovery of Helm releases could occasionally get stuck in a pending state.
 
-Lastly, the new release introduces the ability to enable drift detection on a per-object basis. This includes the option to ignore drift in specific fields using Kustomize-like target selectors and JSON pointer paths, which helps to reduce the noise and prevent upgrades from infinitely cycling. Helm Drift detection and correction also is no longer experimental since this release. Opt-in through `HelmRelease.spec.driftDetection` in the `v2beta2` API.
+Two new controls become available in the CLI (and as annotations) that can either [force](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#forcing-a-release) or [reset](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#resetting-remediation-retries) the `HelmRelease`.
+
+In addition, the latest release improves the observability of the Helm release status by reflecting more detailed historic information in the [describe](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#describe-the-helmrelease) output and in the [status](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#history) of the HelmRelease object.
+
+The long-awaited [Drift Detection](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#drift-detection) feature also received an update. Having first been introduced and tested as a global feature flag, the new release introduces the ability to enable drift detection on a per-object basis.
+
+This includes the option to ignore drift in specific fields using Kustomize-like target selectors and JSON pointer paths, which helps to reduce the noise and prevent upgrades from infinitely cycling. Helm Drift detection and correction also is no longer experimental since this release. To opt-in through `HelmRelease.spec.driftDetection` in the `v2beta2` API, enable Drift Detection mode.
+
+An [example below](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#ignore-rules) shows how Drift Detection can be configured to work with an HPA, where some drift is always expected to occur in the `spec.replicas` field:
+
+```yaml
+spec:
+  driftDetection:
+    mode: enabled
+    ignore:
+      - paths: ["/spec/replicas"]
+```
 
 There's much more in the upcoming Flux v2.2.0 release such as updates and improvements to Flux source-controller, image-reflector-controller, kustomize-controller, notification-controller, and the Flux CLI!
 

--- a/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
+++ b/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
@@ -20,5 +20,5 @@ Lastly, the new release introduces the ability to enable drift detection on a pe
 
 There's much more in the upcoming Flux v2.2.0 release such as updates and improvements to Flux source-controller, image-reflector-controller, kustomize-controller, notification-controller, and the Flux CLI!
 
-If you get stuck with anything or have feedback, we've got a Slack channel, GitHub discussions, and many other ways to get help from the Flux maintainers, contributors, and community: [fluxcd.io/support/](https://fluxcd.io/support/)
+If you need help with anything or have feedback, we've got a Slack channel, GitHub discussions, and many other ways to get help from the Flux maintainers, contributors, and community: [fluxcd.io/support/](https://fluxcd.io/support/)
 

--- a/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
+++ b/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
@@ -16,15 +16,15 @@ While this next release addresses hundreds of issues and has many improvements t
 
 We hope many Flux users will rejoice in the improvements of the updated helm-controller, and that you'll all update to the latest release. This will help, in particular, with the issue of how the automatic recovery of Helm releases could occasionally get stuck in a pending state.
 
-Two new controls become available in the CLI (and as annotations) that can either [force](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#forcing-a-release) or [reset](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#resetting-remediation-retries) the `HelmRelease`.
+Two new controls become available in the CLI (and as annotations) that can either force or reset the `HelmRelease`.
 
-In addition, the latest release improves the observability of the Helm release status by reflecting more detailed historic information in the [describe](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#describe-the-helmrelease) output and in the [status](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#history) of the HelmRelease object.
+In addition, the latest release improves the observability of the Helm release status by reflecting more detailed historic information in the describe() output and in the status of the HelmRelease object.
 
-The long-awaited [Drift Detection](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#drift-detection) feature also received an update. Having first been introduced and tested as a global feature flag, the new release introduces the ability to enable drift detection on a per-object basis.
+The long-awaited Drift Detection feature also received an update. Having first been introduced and tested as a global feature flag, the new release introduces the ability to enable drift detection on a per-object basis.
 
 This includes the option to ignore drift in specific fields using Kustomize-like target selectors and JSON pointer paths, which helps to reduce the noise of notifications and prevent upgrades from infinitely cycling. Helm Drift detection and correction also is no longer experimental starting in this release. To opt-in through `HelmRelease.spec.driftDetection` in the `v2beta2` API, enable Drift Detection mode.
 
-An [example from the docs](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#ignore-rules) below shows how Drift Detection can be configured to work with an HPA, where some drift is always expected to occur in the `spec.replicas` field:
+An example from the docs below shows how Drift Detection can be configured to work with an HPA, where some drift is always expected to occur in the `spec.replicas` field:
 
 ```yaml
 spec:
@@ -40,3 +40,9 @@ There's much more in the upcoming Flux v2.2.0 release, more updates and improvem
 
 If you need help with anything or have feedback, we've got a Slack channel, GitHub discussions, and many other ways to get help from the Flux maintainers, contributors, and community: [fluxcd.io/support/](https://fluxcd.io/support/)
 
+[force]: https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#forcing-a-release
+[reset]: https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#resetting-remediation-retries
+[describe]: https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#describe-the-helmrelease
+[status]: https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#history
+[Drift Detection]: https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#drift-detection
+[example from the docs]: https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#ignore-rules

--- a/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
+++ b/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
@@ -22,9 +22,9 @@ In addition, the latest release improves the observability of the Helm release s
 
 The long-awaited [Drift Detection](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#drift-detection) feature also received an update. Having first been introduced and tested as a global feature flag, the new release introduces the ability to enable drift detection on a per-object basis.
 
-This includes the option to ignore drift in specific fields using Kustomize-like target selectors and JSON pointer paths, which helps to reduce the noise and prevent upgrades from infinitely cycling. Helm Drift detection and correction also is no longer experimental since this release. To opt-in through `HelmRelease.spec.driftDetection` in the `v2beta2` API, enable Drift Detection mode.
+This includes the option to ignore drift in specific fields using Kustomize-like target selectors and JSON pointer paths, which helps to reduce the noise of notifications and prevent upgrades from infinitely cycling. Helm Drift detection and correction also is no longer experimental starting in this release. To opt-in through `HelmRelease.spec.driftDetection` in the `v2beta2` API, enable Drift Detection mode.
 
-An [example below](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#ignore-rules) shows how Drift Detection can be configured to work with an HPA, where some drift is always expected to occur in the `spec.replicas` field:
+An [example from the docs](https://github.com/fluxcd/helm-controller/blob/64fed65148342578c1ed4b2155cd81852c54557a/docs/spec/v2beta2/helmreleases.md#ignore-rules) below shows how Drift Detection can be configured to work with an HPA, where some drift is always expected to occur in the `spec.replicas` field:
 
 ```yaml
 spec:
@@ -34,7 +34,9 @@ spec:
       - paths: ["/spec/replicas"]
 ```
 
-There's much more in the upcoming Flux v2.2.0 release, more updates and improvements for all of Flux's controllers, and a major overhaul of the dependencies from the perspective of image-automation-controller! (Stay tuned for more details in a future post!)
+There's much more in the upcoming Flux v2.2.0 release, more updates and improvements for all of Flux's controllers, and a major overhaul of the dependencies from the perspective of image-automation-controller!
+
+(Stay tuned for more details in a future post!)
 
 If you need help with anything or have feedback, we've got a Slack channel, GitHub discussions, and many other ways to get help from the Flux maintainers, contributors, and community: [fluxcd.io/support/](https://fluxcd.io/support/)
 

--- a/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
+++ b/content/en/blog/2023-12-07-flux-release-around-the-corner/index.md
@@ -34,7 +34,7 @@ spec:
       - paths: ["/spec/replicas"]
 ```
 
-There's much more in the upcoming Flux v2.2.0 release such as updates and improvements to Flux source-controller, image-reflector-controller, kustomize-controller, notification-controller, and the Flux CLI!
+There's much more in the upcoming Flux v2.2.0 release, more updates and improvements for all of Flux's controllers, and a major overhaul of the dependencies from the perspective of image-automation-controller! (Stay tuned for more details in a future post!)
 
 If you need help with anything or have feedback, we've got a Slack channel, GitHub discussions, and many other ways to get help from the Flux maintainers, contributors, and community: [fluxcd.io/support/](https://fluxcd.io/support/)
 


### PR DESCRIPTION
Targeting the release of this blog on Dec 7. We may wait to publish this until the v2.2.0 release is actually available

(Let's put this into a PR today so we can preview, make sure it looks good, and go through reviews - we can start preparing both blogs this way.)

The usual release blog comes out a while after the release, because everyone with an appropriate level of knowledge to write about what goes into the release is currently... working on the release! We'll do a more detailed and thorough post like we usually do, but we got feedback from users that we should link to the blog from the release notes, and we can only do that if the blog is out when the release comes out. Or, a blog. (We can update the blog link once the more detailed post is available, but we should establish this pattern of linking to the release blog from the release notes, if we want our conscientious users to find the blog post and the information in it when they are upgrading.)

I personally think we should wait to announce the release until it's out. The discussion around this post up until now was that we would aim for a target date, and the language reflects that the release is "coming soon." If we're going to post both concurrently, we should make some minor changes to the language to reflect that the release "is out" not "coming soon."

So, this is the pre-release blog. A separate PR will contain the release blog.