### PR TITLE
[v2-0] Bump actions/setup-python from 4 to 5

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'


### PR DESCRIPTION
Manual backport to v2-0 due to failure in automatic backporting of #1737.
