### PR TITLE
Prepare release of Flux 2.2 - v2.1 archive

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -97,12 +97,14 @@ params:
   offlineSearch: false
   version_menu: "Versions"
   version: "2.1"
-  archived_version: false
+  archived_version: true
   version_menu_pagelinks: true
   url_latest_version: https://fluxcd.io/flux/
   versions:
-    - version: "v2.1"
+    - version: "v2.2"
       url: https://fluxcd.io
+    - version: "v2.1"
+      url: https://v2-1.docs.fluxcd.io
     - version: "v2.0"
       url: https://v2-0.docs.fluxcd.io
   logos:


### PR DESCRIPTION
Following the procedure documented in
https://fluxcd.io/flux/releases/procedure/#distribution-minor-release-website.

main branch update in #1741 