### PR TITLE
Add 2.2 backport label

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,6 +1,9 @@
 # Configuration file to declaratively configure labels
 # Ref: https://github.com/EndBug/label-sync#Config-files
 
+- name: backport:v2-2
+  description: To be backported to v2-2
+  color: '#ffd700'
 - name: backport:v2-1
   description: To be backported to v2-1
   color: '#ffd700'


### PR DESCRIPTION
This is in preparation of using the v2-2 branch for the production website fluxcd.io instead of main.
