### PR TITLE
Added SSH over HTTPS port warning to github bootstrapping docs

### DIFF
--- a/content/en/flux/installation/bootstrap/github.md
+++ b/content/en/flux/installation/bootstrap/github.md
@@ -159,5 +159,11 @@ flux bootstrap git \
 
 **Note** that you must generate a SSH private key and set the public key as a deploy key on GitHub in advance.
 
+{{% alert color="warning" title="Using SSH over HTTPS Port" %}}
+https://docs.github.com/en/authentication/troubleshooting-ssh/using-ssh-over-the-https-port
+
+If you encounter known hosts mismatch errors you may need to change the port back to 22 for bootstrapping.
+{{% /alert %}}
+
 For more information on how to use the `flux bootstrap git` command,
 please see the generic Git server [documentation](generic-git-server.md).


### PR DESCRIPTION
Added a warning for an unlikely but potential issue for folks who are using SSH over port 443 when bootstrapping flux. 

I ran into this issue and even with the host keys set to the ones in that link I was unable to get this to work until I changed the port back to 22. 

