### PR TITLE
Test building via netlify (preview-build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "website",
+  "name": "website-test",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "site",
+  "name": "website",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
There appears to be something preventing the front page from updating calendar, I can't see the build logs at Netlify but here we can see the script hasn't run successfully to update the "next upcoming meeting" since before the 18th:

<img width="1234" alt="Screenshot 2024-01-21 at 10 02 57 AM" src="https://github.com/fluxcd/website/assets/3286998/44eaafb5-fc42-48eb-9d38-7a15ab35d201">

I am investigating. I was able to run the `make preview-build` locally and I see no issues. It's not helpful looking at the github actions workflow logs for the periodic `netlify` job, because it doesn't return any status - it's just a trigger that runs a POST and doesn't wait around for the outcome. I may already have access by association to the Netlify production account to review the logs if I can figure out how (or I may need to request access)

I'm just going to see if a preview build works when we run it this way. No reason to expect it shouldn't...