### PR TITLE
Change netlify 6-hourly job to update current release

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -11,3 +11,6 @@ jobs:
       - name: Deploy 'main' on Netlify
         run: |
           curl -X POST -d {} '${{ secrets.NETLIFY_BUILD_HOOK }}'
+          # So fluxcd.io/#calendar advances, rebuild the current minor:
+          # Ref: https://github.com/fluxcd/website/issues/1787
+          curl -X POST -d {} '${{ secrets.NETLIFY_BUILD_HOOK_V22 }}'


### PR DESCRIPTION
Resolves #1787

We will still need to make further changes, once a new minor version is released, or before then, so that this script does not need to change every minor release. It will be easy to make this script self-updating, but someone will still need to create the new build hook variable with Netlify and copy it to the secret, so, at least we can make it one less step.

One other issue is that when this ever fails, there is no notification back on the Actions dashboard. The curl POST calls are asynchronous and they don't return any status here.

Let's merge this and keep it simple, there's no much sense writing a script any more complicated than this one when we can't quite script the whole thing.