### PR TITLE
Add Kubecon page for KubeCon Paris 2024

### DIFF
--- a/assets/scss/_kubecon.scss
+++ b/assets/scss/_kubecon.scss
@@ -1,0 +1,40 @@
+.flux-logo-inner-header-left {
+  width: 33.3333333333%;
+  float: left;
+  figure {
+    padding-left: 3.75%;
+    padding-right: 3.75%;
+  }
+}
+
+.float-header-kubecon {
+  float: left;
+  width: 50%;
+  padding-left: 2.5%;
+  padding-right: 2.5%;
+}
+
+.inner-header-right-align {
+  width: 16.6666666667%;
+  float: left;
+}
+
+.stickers-float-left {
+  width: 50%;
+  float: left;
+  padding-left: 2.5%;
+  padding-right: 2.5%;
+}
+
+.float-booth-fun {
+  width: 50%;
+  float: left;
+  padding-left: 2.5%;
+  padding-right: 2.5%;
+}
+
+.clearfix::after {
+  content: "";
+  clear: both;
+  display: table;
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -12,3 +12,4 @@
 @import "support";
 @import "ecosystem";
 @import "adopters_wall";
+@import "kubecon";

--- a/external-sources/fluxcd/community
+++ b/external-sources/fluxcd/community
@@ -1,2 +1,3 @@
 "/README.md","/community.md"
 "/GOVERNANCE.md","/governance.md"
+"/KUBECON.md","/kubecon.md"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -175,6 +175,9 @@ params:
 
 menus:
   main:
+  - name: KubeCon Paris 2024
+    url: /kubecon
+    weight: 5
   - name: Documentation
     url: /flux
     weight: 10


### PR DESCRIPTION
The deploy preview is ready at:

https://deploy-preview-1804--fluxcd.netlify.app/kubecon/

How this is supposed to work, you can just edit the Google Sites page, and this workflow in:

* fluxcd/community#349

...comes along every 6 hours, wget's the html and feeds it through `html2md`, a Go tool that does a good job of converting HTML into Markdown

Then it runs a bunch of string substitutions on the Markdown output, to make sure we can serve the images from fluxcd.io instead of hot-linking Google Sites. The images all have some semantic associations that are conveyed through alt tags. We can change anything here, but I think it's pretty good for a first pass, and it should only open a Pull Request when there is a substantive change on the Sites.

Then, further string substitutions ensure that the things which should be shown as columns are given semantic containers so we can use CSS to turn them into columns.

We can trigger the workflow every 6 hours (we can shorten this interval during Kubecon - the workflow is fast) or you can trigger it manually, through the workflow dispatch.

The script has a debug mode you can enable with `export DEBUG=1` - the instructions to operate the script are in the header, if you run the script on MacOS, then it will try to use `gsed` and `ghead` that are like the sed and head commands we'll find on our GitHub Actions runner workflow.