### PR TITLE
Update header banner to 2.2 release blog

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -66,8 +66,8 @@ features:
       all have great dashboards for you.
 ---
 
-<!-- {{/* home/announce emoji="📢" url="/blog/..." */}}
-News
+<!-- {{/* home/announce emoji="📢" url="/blog/2023/12/flux-v2.2.0/" */}}
+Announcing Flux 2.2 GA
 {{/* /home/announce */}} -->
 
 <div class="hero-gitops">

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -66,9 +66,9 @@ features:
       all have great dashboards for you.
 ---
 
-<!-- {{/* home/announce emoji="📢" url="/blog/2023/12/flux-v2.2.0/" */}}
+{{% home/announce emoji="📢" url="/blog/2023/12/flux-v2.2.0/" %}}
 Announcing Flux 2.2 GA
-{{/* /home/announce */}} -->
+{{% /home/announce %}}
 
 <div class="hero-gitops">
   {{% blocks/hero title="Flux - the GitOps family of projects" color="primary"

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -66,9 +66,9 @@ features:
       all have great dashboards for you.
 ---
 
-{{% home/announce emoji="📢" url="/blog/2023/07/flux-ga/" %}}
+<!-- {{#% home/announce emoji="📢" url="/blog/2023/07/flux-ga/" %}}
 Flux 2.0 reaches General Availability!
-{{% /home/announce %}}
+{{#% /home/announce %}} -->
 
 <div class="hero-gitops">
   {{% blocks/hero title="Flux - the GitOps family of projects" color="primary"

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -66,9 +66,9 @@ features:
       all have great dashboards for you.
 ---
 
-<!-- {{#% home/announce emoji="📢" url="/blog/2023/07/flux-ga/" %}}
-Flux 2.0 reaches General Availability!
-{{#% /home/announce %}} -->
+<!-- {{/* home/announce emoji="📢" url="/blog/..." */}}
+News
+{{/* /home/announce */}} -->
 
 <div class="hero-gitops">
   {{% blocks/hero title="Flux - the GitOps family of projects" color="primary"

--- a/content/en/ecosystem/index.md
+++ b/content/en/ecosystem/index.md
@@ -26,9 +26,6 @@ as being part of the Flux Ecosystem.
 {{% card header="[D2iQ Kommander](https://d2iq.com/products/kommander)" %}}
 ![D2iQ](/img/logos/d2iq.png)
 {{% /card %}}
-{{% card header="[Weave GitOps](https://www.weave.works/enterprise-flux/)" %}}
-![Weaveworks](/img/logos/weaveworks.png)
-{{% /card %}}
 {{< /cardpane >}}
 </div>
 
@@ -43,7 +40,6 @@ as being part of the Flux Ecosystem.
 | Gimlet      | Gimlet                  | [Documentation](https://gimlet.io/concepts/components/)                              |
 | GitLab      | GitLab                  | [Documentation](https://docs.gitlab.com/ee/user/clusters/agent/gitops.html)          |
 | VMware      | Tanzu                   | [Product Page](https://tanzu.vmware.com/tanzu)                                       |
-| Weaveworks  | Weave Gitops Enterprise | [Product Page](https://www.weave.works/enterprise-flux/)                             |
 
 ## Flux UIs / GUIs
 
@@ -52,7 +48,7 @@ These open source projects offer a dedicated graphical user interface for Flux.
 | Source                                                                              | Description                                                                                                                                                                                                                                                                                                                   |
 |-------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [weaveworks/vscode-gitops-tools](https://github.com/weaveworks/vscode-gitops-tools) | GitOps Tools for Visual Studio Code: provides an intuitive way to manage, troubleshoot and operate your Kubernetes environment following the GitOps operating model                                                                                                                                                           |
-| [weaveworks/weave-gitops](https://github.com/weaveworks/weave-gitops)               | Weaveworks offers a free and open source GUI for Flux under the [weave-gitops](https://docs.gitops.weave.works/docs/intro) project. You can install the Weave GitOps UI using a Flux `HelmRelease`, please see the [get started documentation](https://docs.gitops.weave.works/docs/getting-started/intro/) for more details. |
+| [weaveworks/weave-gitops](https://github.com/weaveworks/weave-gitops)               | Weaveworks offered a free and open source GUI for Flux under the [weave-gitops](https://docs.gitops.weave.works/docs/intro) project. You can install the Weave GitOps UI using a Flux `HelmRelease`, please see the [get started documentation](https://docs.gitops.weave.works/docs/getting-started/intro/) for more details. |
 
 {{< blocks/flux_ui_galleries >}}
 

--- a/content/en/support.md
+++ b/content/en/support.md
@@ -19,21 +19,18 @@ Luckily some of the companies who employ Flux developers offer paid support, so 
 {{% card header="[DoneOps](https://www.doneops.com/#contactus)" %}}
 ![DoneOps](/img/logos/doneops.svg)
 {{% /card %}}
-{{% card header="[Weaveworks](https://www.weave.works/contact/)" %}}
-![Weaveworks](/img/logos/weaveworks.png)
-{{% /card %}}
 {{% card header="[Xenit](https://xenit.se/contact/)" %}}
 ![Xenit](/img/logos/xenit.png)
 {{% /card %}}
 {{< /cardpane >}}
 
-| Involvement / Service                                 | DoneOps | Weaveworks | Xenit |
-| ----------------------------------------------------- | ------- | ---------- | ----- |
-| Involved in Flux Community                            | ✅      | ✅         | ✅    |
-| Employs [Flux Core Maintainers][core-maintainers]     |         | ✅         | ✅    |
-| Offers GitOps infrastructure review and support       | ✅      | ✅         | ✅    |
-| Offers Custom Engineering                             |         | ✅         | ✅    |
-| Offers [Enterprise product based on Flux][enterprise] |         | ✅         |       |
+| Involvement / Service                                 | DoneOps |  Xenit |
+| ----------------------------------------------------- | ------- |  ----- |
+| Involved in Flux Community                            | ✅      |  ✅    |
+| Employs [Flux Core Maintainers][core-maintainers]     |         |  ✅    |
+| Offers GitOps infrastructure review and support       | ✅      |  ✅    |
+| Offers Custom Engineering                             |         |  ✅    |
+| Offers [Enterprise product based on Flux][enterprise] |         |        |
 
 [core-maintainers]: https://github.com/fluxcd/community/blob/main/CORE-MAINTAINERS
 [enterprise]: /ecosystem/#products-and-services-built-on-top-of-flux


### PR DESCRIPTION
This article is from 8 months ago, Flux has had two minor releases since GA. Preserve the banner in an HTML comment so we don't forget how this was done, in case we need to announce something again later.

FWIW, also some links to "August 2 webinar" on that page are no longer good, as weave.works has gone down for the count:

https://go.weave.works/Webinar-FluxCD-Positioned-for-Growth_LP.html