### PR TITLE
update podinfo GitRepository branch to match guide

### DIFF
--- a/content/en/flux/get-started.md
+++ b/content/en/flux/get-started.md
@@ -121,7 +121,7 @@ podinfo is a tiny web application made with Go.
     ```sh
     flux create source git podinfo \
       --url=https://github.com/stefanprodan/podinfo \
-      --branch=master \
+      --branch=main \
       --interval=1m \
       --export > ./clusters/my-cluster/podinfo-source.yaml
     ```


### PR DESCRIPTION
The podinfo `GitRepository` resource was set to use `master` instead of `main`.