### PR TITLE
Fix aenix logo in adopters

### DIFF
--- a/data/adopters/1-flux-v2.yaml
+++ b/data/adopters/1-flux-v2.yaml
@@ -314,4 +314,4 @@ adopters:
       logo: logos/strg-at.png
     - name: Ænix
       url: https://aenix.io
-      logo: logos/aenix.io
+      logo: logos/aenix.svg


### PR DESCRIPTION
Noticed the logo isn't showing up in Adopters, it isn't because of any reason except for mismatched filename.

I have checked that SVG logos are OK here and it appears they are. (@kvaps FYI thanks for adding this here!)