### PR TITLE
Add repository_dispatch to trigger a website rebuild from fluxcd/community

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
+  repository_dispatch:
+    types: [trigger-workflow]
 jobs:
   publish:
     if: github.repository == 'fluxcd/website'


### PR DESCRIPTION
Following the example in:

https://medium.com/hostspaceng/triggering-workflows-in-another-repository-with-github-actions-4f581f8e0ceb#:~:text=Set%20Up%20the%20Trigger%20Workflow,for%20triggering%20the%20target%20workflow.

This exposes the Netlify job as a repository_dispatch, which allows it to be triggered from fluxcd/community.

Some additional configuration may be needed in the `BOT_GITHUB_TOKEN` for fluxcd/community.

See also:

* https://github.com/fluxcd/community/pull/365