### PR TITLE
Add GitHub fine-grained PAT permission to bootstrap docs

### DIFF
--- a/content/en/flux/get-started.md
+++ b/content/en/flux/get-started.md
@@ -14,6 +14,9 @@ To follow the guide, you need the following:
 - **A Kubernetes cluster**. We recommend [Kubernetes kind](https://kind.sigs.k8s.io/docs/user/quick-start/) for trying Flux out in a local development environment.
 - **A GitHub personal access token with repo permissions**. See the GitHub documentation on [creating a personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).
 
+Note that for production use, it is recommended to have a dedicated GitHub account for Flux and 
+use [fine-grained access tokens](/flux/installation/bootstrap/github/#github-organization) with the minimum required permissions.
+
 ## Objectives
 
 - Bootstrap Flux on a Kubernetes Cluster.

--- a/content/en/flux/installation/bootstrap/github.md
+++ b/content/en/flux/installation/bootstrap/github.md
@@ -78,14 +78,15 @@ If you want to use an existing repository, the Flux user must have `admin` permi
 
 {{% alert color="info" title="GitHub fine-grained PAT" %}}
 Bootstrap can be run with a GitHub [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens),
-but the GitHub repository must be created ahead of time by an organization admin.
+for repositories that are created ahead of time by an organization admin.
 
 The fine-grained PAT must be generated with the following permissions:
 
-- `Administration` -> `Access: Read-only` (should be set to `Read and write` when using `bootstrap github --token-auth=false`)
+- `Administration` -> `Access: Read-only`
 - `Contents` -> `Access: Read and write`
 - `Metadata` -> `Access: Read-only`
 
+Note that `Administration` should be set to `Access: Read and write` when using `bootstrap github --token-auth=false`.
 {{% /alert %}}
 
 Run the bootstrap for a repository owned by a GitHub organization:

--- a/content/en/flux/installation/bootstrap/github.md
+++ b/content/en/flux/installation/bootstrap/github.md
@@ -76,6 +76,18 @@ Generate a GitHub PAT for the Flux user that can create repositories by checking
 
 If you want to use an existing repository, the Flux user must have `admin` permissions for that repository.
 
+{{% alert color="info" title="GitHub fine-grained PAT" %}}
+Bootstrap can be run with a GitHub [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens),
+but the GitHub repository must be created ahead of time by an organization admin.
+
+The fine-grained PAT must be generated with the following permissions:
+
+- `Administration` -> `Access: Read-only` (should be set to `Read and write` when using `bootstrap github --token-auth=false`)
+- `Contents` -> `Access: Read and write`
+- `Metadata` -> `Access: Read-only`
+
+{{% /alert %}}
+
 Run the bootstrap for a repository owned by a GitHub organization:
 
 ```sh


### PR DESCRIPTION
Fix: https://github.com/fluxcd/flux2/issues/4412
Fix: https://github.com/fluxcd/flux2/issues/2329
Supersedes: #1722 

PS. These settings were tests on https://github.com/controlplaneio-fluxcd/d1-fleet
