### PR TITLE
Remove ResourceQuota from sharding overlay example

### DIFF
--- a/content/en/flux/installation/configuration/sharding.md
+++ b/content/en/flux/installation/configuration/sharding.md
@@ -54,7 +54,7 @@ commonAnnotations:
   sharding.fluxcd.io/role: "shard"
 patches:
   - target:
-      kind: (Namespace|CustomResourceDefinition|ClusterRole|ClusterRoleBinding|ServiceAccount|NetworkPolicy)
+      kind: (Namespace|CustomResourceDefinition|ClusterRole|ClusterRoleBinding|ServiceAccount|NetworkPolicy|ResourceQuota)
       labelSelector: "app.kubernetes.io/part-of=flux"
     patch: |
       apiVersion: v1


### PR DESCRIPTION
The ResourceQuota resource should not be duplicated by the sharding kustomize overlay.