### PR TITLE
Update ImageUpdateAutomation to v1beta2 API

### DIFF
--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -580,7 +580,7 @@ tags in the YAML manifests stored in the Git repository used at bootstrap.
 First we'll configure Flux to clone the bootstrap repository and push commits to the `main` branch:
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
 metadata:
   name: flux-system
@@ -597,7 +597,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: '{{range .Updated.Images}}{{println .}}{{end}}'
+      messageTemplate: '{{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}'
   update:
     path: ./clusters/my-cluster
     strategy: Setters

--- a/content/en/flux/gitops-toolkit/packages.md
+++ b/content/en/flux/gitops-toolkit/packages.md
@@ -132,7 +132,7 @@ Import package
 ```go
 import (
 	imagev1 "github.com/fluxcd/image-reflector-controller/api/v1beta2"
-	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
+	autov1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
 )
 ```
 
@@ -142,7 +142,7 @@ API Types
 |------------------------------------------------------------------------|---------|
 | [ImageRepository](../components/image/imagerepositories.md)            | v1beta2 |
 | [ImagePolicy](../components/image/imagepolicies.md)                    | v1beta2 |
-| [ImageUpdateAutomation](../components/image/imageupdateautomations.md) | v1beta1 |
+| [ImageUpdateAutomation](../components/image/imageupdateautomations.md) | v1beta2 |
 
 ## CRUD Example
 

--- a/content/en/flux/guides/image-update.md
+++ b/content/en/flux/guides/image-update.md
@@ -312,14 +312,14 @@ flux create image update flux-system \
 --push-branch=main \
 --author-name=fluxcdbot \
 --author-email=fluxcdbot@users.noreply.github.com \
---commit-template="{{range .Updated.Images}}{{println .}}{{end}}" \
+--commit-template="{{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}" \
 --export > ./clusters/my-cluster/flux-system-automation.yaml
 ```
 
 The above command generates the following manifest:
 
 ```yaml
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
 metadata:
   name: flux-system
@@ -337,7 +337,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: '{{range .Updated.Images}}{{println .}}{{end}}'
+      messageTemplate: '{{range .Changed.Changes}}{{print .OldValue}} -> {{println .NewValue}}{{end}}'
     push:
       branch: main
   update:
@@ -502,18 +502,17 @@ spec:
         Automation name: {{ .AutomationObject }}
 
         Files:
-        {{ range $filename, $_ := .Updated.Files -}}
+        {{ range $filename, $_ := .Changed.FileChanges -}}
         - {{ $filename }}
         {{ end -}}
 
         Objects:
-        {{ range $resource, $_ := .Updated.Objects -}}
+        {{ range $resource, $changes := .Changed.Objects -}}
         - {{ $resource.Kind }} {{ $resource.Name }}
+          Changes:
+        {{- range $_, $change := $changes }}
+            - {{ $change.OldValue }} -> {{ $change.NewValue }}
         {{ end -}}
-
-        Images:
-        {{ range .Updated.Images -}}
-        - {{.}}
         {{ end -}}
       author:
         email: fluxcdbot@users.noreply.github.com

--- a/content/en/flux/migration/flux-v1-automation-migration.md
+++ b/content/en/flux/migration/flux-v1-automation-migration.md
@@ -291,7 +291,7 @@ $ flux create image update my-app-auto \
     --export > ./$AUTO_PATH/my-app-auto.yaml
 $ cat my-app-auto.yaml
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
 metadata:
   name: my-app-auto
@@ -337,8 +337,8 @@ $ flux reconcile kustomization --with-source flux-system
 ✔ Kustomization reconciliation completed
 ✔ reconciled revision main@sha1:401dd3b550f82581c7d12bb79ade389089c6422f
 $ flux get image update
-NAME            READY   MESSAGE         LAST RUN                SUSPENDED
-my-app-auto     True    no updates made 2021-02-08T14:53:43Z    False
+NAME            LAST RUN                    SUSPENDED       READY   MESSAGE
+my-app-auto     2021-02-08T14:53:43Z        False           True    repository up-to-date
 ```
 
 Read on to the next section to see how to change each manifest file to work with Flux v2.


### PR DESCRIPTION
Depends on https://github.com/fluxcd/image-automation-controller/pull/647, to be release as part of Flux v2.3 release.

- Update all the references of v1beta1 API to v1beta2
- Update the outputs and template examples to use the new results
