### PR TITLE
Hide the KubeCon Paris menu entry

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -175,9 +175,6 @@ params:
 
 menus:
   main:
-  - name: KubeCon Paris 2024
-    url: /kubecon
-    weight: 5
   - name: Documentation
     url: /flux
     weight: 10


### PR DESCRIPTION
The menu entry is removed by this PR, but the URL `fluxcd.io/kubecon` stays valid and intact. Filing this as a piece of the puzzle in response to @stefanprodan's request. It is a good idea to keep the link perpetually valid, as people may still have the QR code, we can update it to point at later versions though.

I think later we still would make two further adjustments, at some future date (not before we merge this):

1. Move the KubeCon Paris markdown file to some historical place here in the `fluxcd/website` repository
  * [ ] copy the `KUBECON.md` file from Community repo into an attic file `KubeconParis2024.md` in the website repo
  * [ ] disable the external-source pointing to `fluxcd/community#main` file `KUBECON.md` at that time as well
  * [ ] We should reserve the `/kubecon` as a redirect that points to the attic file
2. Then in the (further) future, when we are preparing for next KubeCon, we can re-enable `/kubecon` as an external source - put back exactly like 78c7e102684fa44f4231744096c3f31e65660e1e (#1804)

We don't have to do Google Sites if we don't want, we could use any markdown editor for this, (but I think it worked well on Google Sites wdyt @mewzherder?) and if we switch to a plain vanilla markdown editor, or HackMD or something, then I think we would have to find another way to handle columns next time, or further simplify the layout so we don't need them anymore - don't want to make it too boring.