### PR TITLE
Accommodate missing 'organizer' field in calendar

### DIFF
--- a/layouts/shortcodes/home/calendar.html
+++ b/layouts/shortcodes/home/calendar.html
@@ -18,10 +18,12 @@
                         <dd>{{ .where }}</dd>
                     </li>
 
+                    {{ if and .org_email .org_name }}
                     <li>
                         <dt>Organizer</dt>
                         <dd><a href="mailto:{{ .org_email }}">{{ .org_name }}</a></dd>
                     </li>
+                    {{ end }}
                 </ul>
 
                <span class="description">{{ .description | safeHTML }}</span>


### PR DESCRIPTION
Since yesterday the calendar at lists.cncf.io stopped including the 'organizer' field in the ICS file we use for generating the event list on the website.

This PR makes sure that we can handle this case while generating the website in order to fix the broken Netlify deployment.

It also simplifies the Python script a little in that it doesn't use an intermediary dictionary that is in turn transformed to the final dictionary that is then serialized to YAML. Now, the final dictionary is directly generated without an intermediary one.
