### PR TITLE
add timestamp to fix calendar sort

### DIFF
--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -96,6 +96,7 @@ def read_calendar(cal):
                 'label': str(event['summary']),
                 'where': format_location_html(event_location),
                 'description': description,
+                'timestamp': event_time,
         }
 
         if 'organizer' in event:
@@ -104,7 +105,7 @@ def read_calendar(cal):
 
         events.append(formatted_event)
 
-    events.sort(key=lambda e: e['time'])
+    events.sort(key=lambda e: e['timestamp'])
     return events
 
 def format_location_html(location):


### PR DESCRIPTION
Fix issue introduced in #1891 

(the issue: the team calendar's sort order is now out of whack)

<img width="603" alt="Screenshot 2024-04-04 at 8 30 45 AM" src="https://github.com/fluxcd/website/assets/3286998/f399888a-8875-45a7-8af2-826082e53b8a">


There was some implicit sorting and some re-sorting, it's probably clearer if we pass the original timestamp through to the "formatted_event" and sort by that field (even though it is not used directly for display)