### PR TITLE
WIP: Update go for hugo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG HUGO_VERSION
 FROM fluxcd/website:hugo-${HUGO_VERSION}-extended
-COPY --from=golang:1.19-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.21-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/content/en/.gitignore
+++ b/content/en/.gitignore
@@ -2,4 +2,5 @@
 community.md
 contributing.md
 governance.md
+kubecon.md
 security.md

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/fluxcd/website
 
-go 1.18
+go 1.21.6
+
+toolchain go1.22.1
 
 require (
-	github.com/google/docsy v0.6.0 // indirect
-	github.com/google/docsy/dependencies v0.6.0 // indirect
-	github.com/mfg92/hugo-shortcode-gallery v0.0.0-20230213173546-50e99e854f92 // indirect
+	github.com/google/docsy v0.9.1 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+	github.com/mfg92/hugo-shortcode-gallery v1.1.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
-github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
-github.com/google/docsy/dependencies v0.6.0 h1:BFXDCINbp8ZuUGl/mrHjMfhCg+b1YX+hVLAA5fGW7Pc=
-github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
-github.com/mfg92/hugo-shortcode-gallery v0.0.0-20230213173546-50e99e854f92 h1:uQSat8EsvCDjt9ztbhel+yBOp/7fEID4BNkn7hNmQpc=
-github.com/mfg92/hugo-shortcode-gallery v0.0.0-20230213173546-50e99e854f92/go.mod h1:uP48acoDrLxll/agXBGFRWEv5F237K3XKWyAeVZ+Mm8=
-github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
+github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/mfg92/hugo-shortcode-gallery v1.1.1 h1:SQfyXMG3LaJ7aRVa/Lta8UP61VG6SESh19qe6XZsi+k=
+github.com/mfg92/hugo-shortcode-gallery v1.1.1/go.mod h1:zKnMCx7OJJPTfVNalUAFGkNVABLCqIuPl57NeBtSFc0=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
I am trying to reproduce the build environment locally and I'm noticing some things are out of date and other things are not buildable anymore.

WIP: I am working out what we can upgrade so that people can do the build locally, or we can give them a dev container to do it in.

Docsy has also been upgraded, and there are some errors in the local build, but I'm having a hard time working out if these issues are caused by Docsy upgrade, hugo upgrade, something wrong with my site environment, or another issue altogether.

(Please stand by)