### PR TITLE
Upgrade go to 1.21, clean up build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG HUGO_VERSION
 FROM fluxcd/website:hugo-${HUGO_VERSION}-extended
-COPY --from=golang:1.19-alpine /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.21-alpine /usr/local/go/ /usr/local/go/
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/content/en/.gitignore
+++ b/content/en/.gitignore
@@ -2,4 +2,5 @@
 community.md
 contributing.md
 governance.md
+kubecon.md
 security.md

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/website
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/docsy v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluxcd/website
 
-go 1.19
+go 1.21
 
 require (
 	github.com/google/docsy v0.6.0 // indirect

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -84,10 +84,12 @@ outputFormats:
   SearchIndex:
     baseName: index
     mediaType: application/json
+    isPlainText: true
+    notAlternative: true
 
 outputs:
   home: [HTML, SearchIndex]
-  page: [HTML, SearchIndex]
+  page: [HTML]
 
 params:
   description: Open and extensible continuous delivery solution for Kubernetes.


### PR DESCRIPTION
I have narrowed down the issues upgrading hugo to a docsy v0.7.0 release breaking change that brings Bootstrap 5.

I don't know the exact nature of the errors I get with those upgrades, but the good news is it looks like Hugo upstream is already using Go 1.21, so we should at least upgrade to that version to match.

I will investigate the Bootstrap 5 upgrade situation further and get back to us soon about it. In the mean time, I've done loads of testing with `make production-build URL=https://fluxcd.io` on different versions of go modules and go compilers, to determine that this combination works, and we do not have to stay on Go 1.19 any longer.

(Doing one more test locally, since I do not think there is any CI workflow other than the hugo-support image builder that will trigger, and that triggers on merge, so there will be no other chance or automated way to test this before merge)