### PR TITLE
Update documentation for Helm GA

### DIFF
--- a/content/en/flagger/install/flagger-install-with-flux.md
+++ b/content/en/flagger/install/flagger-install-with-flux.md
@@ -41,7 +41,7 @@ metadata:
 Define a Flux `HelmRepository` that points to where the Flagger Helm charts are stored:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: flagger
@@ -56,7 +56,7 @@ Define a Flux `HelmRelease` that verifies and installs Flagger's latest version 
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: flagger

--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -96,7 +96,7 @@ defining Helm releases with charts stored in container registries.
 Example:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -106,7 +106,7 @@ spec:
   type: oci
   url: oci://ghcr.io/stefanprodan/charts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -443,7 +443,7 @@ cosign sign --key cosign.key <registry-host>/<org>/charts/<app-name>:<app-versio
 You can configure Flux to verify the chart signature before installing and upgrading a Helm release:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: helm-charts
@@ -452,7 +452,7 @@ spec:
   url: oci://<registry-host>/<org>/charts
   type: oci
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: <app-name>
@@ -683,7 +683,7 @@ spec:
 Then add the policy marker to the `HelmRelease` manifest in Git:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/cheatsheets/troubleshooting.md
+++ b/content/en/flux/cheatsheets/troubleshooting.md
@@ -219,7 +219,7 @@ Deployment is not ready: default/podinfo. 0 out of 1 expected pods are ready
 To inspect the failing resources, you can disable the health checks with:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
  name: podinfo

--- a/content/en/flux/faq.md
+++ b/content/en/flux/faq.md
@@ -321,7 +321,7 @@ You can take advantage of Flux's OCI and native Helm features,
 by replacing the `kustomization.yaml` with a Flux Helm definition:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kyverno
@@ -331,7 +331,7 @@ spec:
   url: oci://ghcr.io/kyverno/charts
   type: oci
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kyverno
@@ -441,7 +441,7 @@ Create a Helm release with `kubectl`:
 ```sh
 cat << EOF | kubectl apply -f -
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bitnami
@@ -450,7 +450,7 @@ spec:
   interval: 30m
   url: https://charts.bitnami.com/bitnami
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: metrics-server
@@ -480,7 +480,7 @@ when Bitnami publishes a new version of the metrics-server chart.
 Lets assume we have a common `HelmRelease` definition we use as a base and we
 we need to further customize it e.g per cluster, tenant, environment and so on:
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -534,7 +534,7 @@ spec:
 #### Using Kustomize variable substitution
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/flux-e2e.md
+++ b/content/en/flux/flux-e2e.md
@@ -621,7 +621,7 @@ The health checking feature is called [Health Checks][] in the Flux Kustomizatio
 [Helm Use Case]: /flux/use-cases/helm/
 [HelmRepository API]: /flux/components/source/helmrepositories/
 [HelmChart API]: /flux/components/source/helmcharts/
-[HelmChartTemplate.spec.reconcileStrategy]: /flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate
+[HelmChartTemplate.spec.reconcileStrategy]: /flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.HelmChartTemplate
 [Setup Notifications]: /flux/guides/notifications/
 [Alert API]: /flux/components/notification/alert/
 [Event API]: /flux/components/notification/event/

--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -252,6 +252,7 @@ for more details.
 
 ### Using a chart reference
 
+It is possible to reference a chart directly from an `OCIRepository`:
 ```yaml
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
@@ -267,16 +268,34 @@ spec:
     replicaCount: 2
 ```
 
+
+Or a `HelmChart`:
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: podinfo
+spec:
+  chartRef:
+    kind: HelmChart
+    name: podinfo
+    namespace: flux-system
+  interval: 30s
+  values:
+    replicaCount: 2
+```
+
 The `.chartRef` field is used to reference a `OCIRepository` or `HelmChart` resource.
 The helm-controller will then look up the chart in the artifact of the referenced source,
 and fetch it directly.
 
 The pros of using a chart reference are:
 - The chart is fetched directly from the source, without the need to create a `HelmChart`
-  resource. This can reduces the number of resources in the cluster.
-- In the case of a `OCIRepository`, the fact that it is possible to pin on a
-  specific `tag` or `digest` makes it easier to enfore that a specific chart is
-  used, and overall more flexible.
+  resource for the sepcif `HelmRelease`. This can reduces the number of resources
+  in the cluster.
+- In the case of a `OCIRepository`, the fact that it is possible to pin to a
+  specific `tag` or `digest` makes it easier to enforce a specific change, and
+  overall more flexible.
 
 **Note**: When switching from a `chart.Spec` to a `chartRef`, the old `HelmChart`
 resource is garbage collected by the helm-controller.

--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -178,12 +178,12 @@ spec:
 The source-controller will fetch the Helm chart from the OCI registry namespace 
 on an interval and expose it as an artifact.
 
-The `interval` defines at which interval the OCI repository contents
+The `interval` defines the interval at which the OCI repository contents
 are fetched, and should be at least `1m`. Setting this to a higher
 value means newer chart versions will be detected at a slower pace,
-a push-based fetch can be introduced using [webhook receivers](webhook-receivers.md)
+a push-based fetch can be introduced using [webhook receivers](webhook-receivers.md).
 
-The `url` has to point to a registry repository and to start with `oci://`.
+The `url` has to point to a registry repository and start with prefix `oci://`.
 
 The `ref` defines the checkout strategy, and can be one of `tag`, `digest` or `semver`.
 When using `semver`, an optional `semverFilter` can be provided to filter the tags.
@@ -197,7 +197,9 @@ for more details.
 
 ## Define a Helm release
 
-To release a Helm chart, a `HelmRelease` resource has to be created.
+To release a Helm chart, a `HelmRelease` resource has to be created. The `HelmRelease`
+resources can either reference an existing `OCIRepository` or `Helmchart` resource,
+or it creates a new `HelmChart` resource and manages it.
 
 ### Using a chart template
 
@@ -297,7 +299,7 @@ The pros of using a chart reference are:
   specific `tag` or `digest` makes it easier to enforce a specific change, and
   overall more flexible.
 
-**Note**: When switching from a `chart.Spec` to a `chartRef`, the old `HelmChart`
+**Note**: When switching from a `.chart.spec` to a `.chartRef`, the old `HelmChart`
 resource is garbage collected by the helm-controller.
 
 ## Refer to values in `ConfigMaps` generated with Kustomize

--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -44,7 +44,7 @@ The source-controller will fetch the Helm repository index for this
 resource on an interval and expose it as an artifact:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -75,7 +75,7 @@ For HTTP/S repositories, the credentials can be provided as a secret reference w
 basic authentication.
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -202,13 +202,13 @@ To release a Helm chart, a `HelmRelease` resource has to be created.
 ### Using a chart template
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
   namespace: default
 spec:
-  interval: 5m
+  interval: 10m
   chart:
     spec:
       chart: <name|path>
@@ -217,7 +217,7 @@ spec:
         kind: <HelmRepository|GitRepository|Bucket>
         name: podinfo
         namespace: flux-system
-      interval: 1m
+      interval: 10m
   values:
     replicaCount: 2
 ```
@@ -254,7 +254,7 @@ for more details.
 
 It is possible to reference a chart directly from an `OCIRepository`:
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -263,7 +263,7 @@ spec:
     kind: OCIRepository
     name: podinfo
     namespace: flux-system
-  interval: 30s
+  interval: 10m
   values:
     replicaCount: 2
 ```
@@ -271,7 +271,7 @@ spec:
 
 Or a `HelmChart`:
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -280,7 +280,7 @@ spec:
     kind: HelmChart
     name: podinfo
     namespace: flux-system
-  interval: 30s
+  interval: 10m
   values:
     replicaCount: 2
 ```
@@ -320,13 +320,13 @@ nameReference:
 Create a `HelmRelease` definition that references a `ConfigMap`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
   namespace: podinfo
 spec:
-  interval: 5m
+  interval: 10m
   releaseName: podinfo
   chart:
     spec:
@@ -361,7 +361,7 @@ When [kustomize-controller](../components/kustomize/_index.md) reconciles the ab
 a unique name of the `ConfigMap` every time `my-values.yaml` content is updated in Git:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -401,13 +401,13 @@ nameReference:
 Create a `HelmRelease` definition that references a `Secret`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
   namespace: podinfo
 spec:
-  interval: 5m
+  interval: 10m
   releaseName: podinfo
   chart:
     spec:
@@ -504,13 +504,13 @@ in the context then they can recover decrypted values using `helm get values`.
 It is possible to replace the `values.yaml` with a different file present inside the Helm chart.
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: mongodb
   namespace: mongodb
 spec:
-  interval: 5m
+  interval: 10m
   chart:
     spec:
       chart: mongodb
@@ -637,7 +637,7 @@ It is possible to create a new chart artifact when a Source's revision has chang
 `version` in the Chart.yml has not been bumped, for `GitRepository` and `Bucket` sources.
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmChart
 metadata:
   name: podinfo

--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -67,26 +67,6 @@ Helm repositories. See the [`HelmRepository` CRD docs](../components/source/helm
 for more details.
 {{% /alert %}}
 
-#### Helm OCI repository
-
-The source-controller performs the Helm repository url validation i.e. the url is
-a valid OCI registry url.
-
-The URL is expected to point to a registry repository and to start with `oci://`.
-
-```yaml
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: podinfo
-  namespace: default
-spec:
-  type: oci
-  interval: 5m0s
-  url: oci://ghcr.io/stefanprodan/charts
-```
-
 #### Helm repository authentication with credentials
 
 In order to use a private Helm repository, you may need to provide the credentials.
@@ -114,33 +94,6 @@ metadata:
 stringData:
   username: example
   password: "123456"
-```
-
-For OCI repositories, the credentials can be provided alternatively as a secret reference
-with dockerconfig authentication.
-
-```yaml
----
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: HelmRepository
-metadata:
-  name: podinfo
-  namespace: default
-spec:
-  interval: 5m0s
-  url: oci://ghcr.io/stefanprodan/charts
-  type: "oci"
-  secretRef:
-    name: regcred
-```
-
-The Docker registry Secret `regcred` can be created with `kubectl`:
-
-```shell
-kubectl create secret docker-registry regcred \
- --docker-server=ghcr.io \
- --docker-username=gh-user \
- --docker-password=gh-token
 ```
 
 ### Git repository
@@ -204,7 +157,7 @@ as the source-controller will download the whole storage bucket at each sync. Th
 bucket can easily become very large if there are frequent releases of multiple charts
 that are stored in the same bucket.
 
-A better option is to use an [OCI registry for chart storage](#helm-oci-repository).
+A better option is to use an [OCI registry for chart storage](#oci-repository).
 
 ### OCI repository
 

--- a/content/en/flux/guides/image-update.md
+++ b/content/en/flux/guides/image-update.md
@@ -404,7 +404,7 @@ Here are some examples of using this marker in a variety of Kubernetes resources
 `HelmRelease` example:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/guides/repository-structure.md
+++ b/content/en/flux/guides/repository-structure.md
@@ -230,14 +230,14 @@ App repository Helm chart example:
 Delivery example (stored in config repo):
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: apps
 spec:
   url: https://<host>/<org>/charts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: app

--- a/content/en/flux/guides/sealed-secrets.md
+++ b/content/en/flux/guides/sealed-secrets.md
@@ -122,7 +122,7 @@ to the fleet repository.
 Helm repository manifest:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: sealed-secrets
@@ -135,7 +135,7 @@ spec:
 Helm release manifest:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: sealed-secrets

--- a/content/en/flux/installation/configuration/sharding.md
+++ b/content/en/flux/installation/configuration/sharding.md
@@ -243,7 +243,7 @@ to the `shard1` controllers, label the HelmRelease, its chart and its repository
 with `sharding.fluxcd.io/key: shard1`:
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -255,7 +255,7 @@ spec:
   type: oci
   url: oci://ghcr.io/stefanprodan/charts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -309,7 +309,7 @@ spec:
     - target:
         kind: HelmRelease
       patch: |
-        apiVersion: helm.toolkit.fluxcd.io/v2beta2
+        apiVersion: helm.toolkit.fluxcd.io/v2
         kind: HelmRelease
         metadata:
           name: all

--- a/content/en/flux/migration/helm-operator-migration.md
+++ b/content/en/flux/migration/helm-operator-migration.md
@@ -34,7 +34,7 @@ From a technical perspective, this also means less overhead, as the resources ma
 
 Due to the Helm Controller becoming part of the extensive set of controller components Flux now has, the Custom Resource group domain has changed from `helm.fluxcd.io` to `helm.toolkit.fluxcd.io`.
 
-Together with the new API version (`v2beta2` at time of writing), the full `apiVersion` you use in your YAML document becomes `helm.toolkit.fluxcd.io/v2beta2`.
+Together with the new API version (`v2` at time of writing), the full `apiVersion` you use in your YAML document becomes `helm.toolkit.fluxcd.io/v2`.
 
 ### The API specification changed (quite a lot), for the better
 
@@ -76,7 +76,7 @@ Getting similar behaviour is still possible [using a workaround that makes use o
 
 There was a long outstanding request for the Helm Operator to support merging single values at a given path.
 
-With the Helm Controller this now possible by defining a [`targetPath` in the `ValuesReference`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.ValuesReference), which supports the same formatting as you would supply as an argument to the `helm` binary using `--set [path]=[value]`. In addition to this, the referred value can contain the same value formats (e.g. `{a,b,c}` for a list). You can read more about the available formats and limitations in the [Helm documentation](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set).
+With the Helm Controller this now possible by defining a [`targetPath` in the `ValuesReference`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.ValuesReference), which supports the same formatting as you would supply as an argument to the `helm` binary using `--set [path]=[value]`. In addition to this, the referred value can contain the same value formats (e.g. `{a,b,c}` for a list). You can read more about the available formats and limitations in the [Helm documentation](https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set).
 
 ### Support added for depends-on relationships
 
@@ -115,7 +115,7 @@ $ flux create source helm podinfo \
     --interval=10m \
     --export
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -131,7 +131,7 @@ $ flux create helmrelease podinfo \
     --chart-version=">4.0.0" \
     --export
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -175,11 +175,11 @@ spec:
     version: 1.2.3
 ```
 
-With the Helm Controller, you now create a `HelmRepository` resource in addition to the `HelmRelease` you would normally create (for all available fields, consult the [Source API reference](/flux/components/source/api/v1beta2/#source.toolkit.fluxcd.io/v1beta2.HelmRepository)):
+With the Helm Controller, you now create a `HelmRepository` resource in addition to the `HelmRelease` you would normally create (for all available fields, consult the [Source API reference](/flux/components/source/api/v1/#source.toolkit.fluxcd.io/v1.HelmRepository)):
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: my-repository
@@ -209,7 +209,7 @@ data:
   keyFile: <base64 encoded key>
   caFile: <base64 encoded CA certificate>
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: my-repository
@@ -220,11 +220,11 @@ spec:
     name: my-repository-creds
 ```
 
-In the `HelmRelease`, you then use a reference to the `HelmRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate)):
+In the `HelmRelease`, you then use a reference to the `HelmRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.HelmChartTemplate)):
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -322,11 +322,11 @@ spec:
     name: my-repository-creds
 ```
 
-In the `HelmRelease`, you then use a reference to the `GitRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmChartTemplate)):
+In the `HelmRelease`, you then use a reference to the `GitRepository` resource in the `spec.chart.spec` (for all available fields, consult the [Helm API reference](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.HelmChartTemplate)):
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -356,7 +356,7 @@ Inlined values (defined in the `spec.values` of the `HelmRelease`) still work as
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -404,11 +404,11 @@ spec:
       optional: true
 ```
 
-In the new API spec the individual `configMapKeyRef` and `secretKeyRef` objects are bundled into a single [`ValuesReference`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.ValuesReference) which [does no longer allow refering to resources in other namespaces](#values-from-external-source-references-urls-are-no-longer-supported):
+In the new API spec the individual `configMapKeyRef` and `secretKeyRef` objects are bundled into a single [`ValuesReference`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.ValuesReference) which [does no longer allow refering to resources in other namespaces](#values-from-external-source-references-urls-are-no-longer-supported):
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -452,7 +452,7 @@ With the Helm Controller, this declaration has moved to the `spec.chart.spec`, a
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -572,7 +572,7 @@ You can now refer to the `my-external-values` `ConfigMap` resource in your `Helm
 
 ```yaml
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -588,7 +588,7 @@ spec:
 
 With the Helm Operator the release options used to be configured in the `spec` of the `HelmRelease` and applied to both Helm install and upgrade actions.
 
-This has changed for the Helm Controller, where some defaults can be defined in the [`spec`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.HelmReleaseSpec), but specific action configurations and overwrites for the defaults can be defined in the [`spec.install`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Install), [`spec.upgrade`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Upgrade) and [`spec.test`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Test) sections of the `HelmRelease`.
+This has changed for the Helm Controller, where some defaults can be defined in the [`spec`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.HelmReleaseSpec), but specific action configurations and overwrites for the defaults can be defined in the [`spec.install`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Install), [`spec.upgrade`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Upgrade) and [`spec.test`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Test) sections of the `HelmRelease`.
 
 ### Defining a rollback / uninstall configuration
 
@@ -613,14 +613,14 @@ spec:
     timeout: 300
 ```
 
-The Helm Controller offers an extensive set of configuration options to remediate when a Helm release fails, using [`spec.install.remediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.InstallRemediation), [`spec.upgrade.remediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation), [`spec.rollback`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Rollback) and [`spec.uninstall`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Uninstall). Some of the new features include the option to remediate with an uninstall after an upgrade failure, and the option to keep a failed release for debugging purposes when it has run out of retries.
+The Helm Controller offers an extensive set of configuration options to remediate when a Helm release fails, using [`spec.install.remediation`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.InstallRemediation), [`spec.upgrade.remediation`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.UpgradeRemediation), [`spec.rollback`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2.Rollback) and [`spec.uninstall`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Uninstall). Some of the new features include the option to remediate with an uninstall after an upgrade failure, and the option to keep a failed release for debugging purposes when it has run out of retries.
 
 #### Automated uninstalls
 
-The configuration below mimics the uninstall behavior of the Helm Operator (for all available fields, consult the [`InstallRemediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.InstallRemediation) and [`Uninstall`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Uninstall) API references):
+The configuration below mimics the uninstall behavior of the Helm Operator (for all available fields, consult the [`InstallRemediation`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.InstallRemediation) and [`Uninstall`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Uninstall) API references):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -643,10 +643,10 @@ spec:
 
 #### Automated rollbacks
 
-The configuration below shows an automated rollback configuration that equals [the configuration for the Helm Operator showed above](#defining-a-rollback--uninstall-configuration) (for all available fields, consult the [`UpgradeRemediation`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation) and [`Rollback`](/flux/components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Rollback) API references):
+The configuration below shows an automated rollback configuration that equals [the configuration for the Helm Operator showed above](#defining-a-rollback--uninstall-configuration) (for all available fields, consult the [`UpgradeRemediation`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.UpgradeRemediation) and [`Rollback`](/flux/components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Rollback) API references):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -717,7 +717,7 @@ The custom resources for the Helm Controller would be:
 
 ```yaml
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -726,7 +726,7 @@ spec:
   interval: 10m
   url: https://stefanprodan.github.io/podinfo
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -96,7 +96,10 @@ with fields that can be used to determine the chart version that was deployed:
 - optional `metadata.oci-digest`: the OCI digest of the oci artifact deployed in
   case of an `OCIRepository` source.
 
-Example of `.github/workflows/demo-promotion.yaml`:
+### Promoting a HelmRelease with a chart version
+
+The following `.github/workflows/demo-promotion.yaml` workflow will react to the Flux
+repository dispatch events and promote the Helm release to the production cluster.
 
 ```yaml
 name: demo-promotion
@@ -126,8 +129,6 @@ jobs:
       - name: Get chart version from staging
         id: staging
         run: |
-          # For OCIRepository source, use the oci-digest field instead of revision.
-          # e.g. DIGEST=$(echo ${{ github.event.client_payload.metadata.oci-digest }} | cut -d '@' -f1)
           VERSION=$(echo ${{ github.event.client_payload.metadata.revision }} | cut -d '@' -f1)
           echo VERSION=${VERSION} >> $GITHUB_OUTPUT
       # Patch the chart version in the production Helm release manifest.
@@ -159,6 +160,83 @@ The above workflow does the following:
 - Clones the `main` branch where the Flux `HelmRelease` YAML manifests are defined.
 - Parses the event metadata to determine the chart version deployed on staging.
 - Patches the chart version in the `HelmRelease` manifest at `clusters/production/apps/demo.yaml`.
+- Creates a new branch called `demo-promotion`, commits the version change and opens a Pull Request against `main`.
+
+**Note** that you should adapt the workflow to match your release name, namespace and YAML path.
+
+### Promoting a HelmRelease using OCI digests
+
+The following `.github/workflows/demo-promotion.yaml` workflow will react to the Flux
+repository dispatch events and promote the Helm release to the production cluster.
+
+The expected `HelmRelease` is one with a `OCIRepository` source.
+
+```yaml
+name: demo-promotion
+on:
+  repository_dispatch:
+    types:
+      - HelmRelease/demo.apps
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    # Start promotion when the staging cluster has successfully
+    # upgraded the Helm release to a new chart version.
+    if: |
+      github.event.client_payload.metadata.env == 'staging' &&
+      github.event.client_payload.severity == 'info'
+    steps:
+      # Checkout main branch.
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      # Parse the event metadata to determine the chart version deployed on staging.
+      - name: Get chart version from staging
+        id: staging
+        run: |
+          DIGEST=$(echo ${{ github.event.client_payload.metadata.oci-digest }} | cut -d '@' -f1)
+          echo DIGEST=${DIGEST} >> $GITHUB_OUTPUT
+          VERSION=$(echo ${{ github.event.client_payload.metadata.revision }} | cut -d '@' -f1)
+          echo VERSION=${VERSION} >> $GITHUB_OUTPUT
+      # Patch the digest in the production OCIRepository manifest.
+      - name: Set chart version in production
+        id: production
+        env:
+          DIGEST: ${{ steps.staging.outputs.digest }}
+        run: |
+          echo "set ociRepository digest to ${DIGEST}"
+          # This will filter out all resources that do not have a digest field.
+          yq eval '(select(.spec.ref.digest) | .spec.ref.digest) = env(DIGEST)' -i ./clusters/production/apps/demo.yaml
+          # add the chart version as a line comment
+          env lc="version ${{ steps.staging.outputs.version }}" \
+          yq eval '(select(.spec.ref.digest) | .spec.ref.digest) line_comment=env(lc)' -i ./clusters/production/apps/demo.yaml
+      # Open a Pull Request if an upgraded is needed in production.
+      - name: Open promotion PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: demo-promotion
+          delete-branch: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update demo to v${{ steps.staging.outputs.version }} with digest ${{ steps.staging.outputs.digest }}
+          title: Promote demo release to v${{ steps.staging.outputs.version }} with digest ${{ steps.staging.outputs.digest }}
+          body: |
+            Promote demo release on production to v${{ steps.staging.outputs.version }} with digest ${{ steps.staging.outputs.digest }}
+            
+```
+
+The above workflow does the following:
+
+- Runs on repository dispatch events issued by Flux with the `HelmRelease/demo.apps` type.
+- Filters the events to take into consideration only success Helm release upgrades.
+- Clones the `main` branch where the Flux `HelmRelease` YAML manifests are defined.
+- Parses the event metadata to determine the chart version deployed on staging
+  and the corresponding OCI digest.
+- Patches the digest in the `OCIRepository` manifest at `clusters/production/apps/demo.yaml`.
 - Creates a new branch called `demo-promotion`, commits the version change and opens a Pull Request against `main`.
 
 **Note** that you should adapt the workflow to match your release name, namespace and YAML path.

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -93,7 +93,7 @@ GitHub workflow that reacts to Flux repository dispatch events.
 The `event` that Flux generate for a `HelmRelease` upgrade contains metadata about the event,
 with fields that can be used to determine the chart version that was deployed:
 - `metadata.revision`: the Helm chart version deployed.
-- optional `metadata.oci-digest`: the OCI digest of the oci artifact deployed in
+- `metadata.oci-digest`(optional): the OCI digest of the oci artifact deployed in
   case of an `OCIRepository` source.
 
 ### Promoting a HelmRelease with a chart version

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -126,6 +126,8 @@ jobs:
       - name: Get chart version from staging
         id: staging
         run: |
+          # For OCIRepository source, use the oci-digest field instead of revision.
+          # e.g. DIGEST=$(echo ${{ github.event.client_payload.metadata.oci-digest }} | cut -d '@' -f1)
           VERSION=$(echo ${{ github.event.client_payload.metadata.revision }} | cut -d '@' -f1)
           echo VERSION=${VERSION} >> $GITHUB_OUTPUT
       # Patch the chart version in the production Helm release manifest.

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -37,7 +37,7 @@ and it will automatically upgrade the Helm release to the latest chart version b
 Example of `clusters/staging/apps/demo.yaml`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: demo
@@ -65,7 +65,7 @@ update in Git by GitHub Actions based on the Flux events.
 Example of `clusters/production/apps/demo.yaml`:
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: demo

--- a/content/en/flux/use-cases/gh-actions-helm-promotion.md
+++ b/content/en/flux/use-cases/gh-actions-helm-promotion.md
@@ -90,6 +90,12 @@ spec:
 To promote a chart version that was successfully deployed and tested on staging, we'll create a
 GitHub workflow that reacts to Flux repository dispatch events.
 
+The `event` that Flux generate for a `HelmRelease` upgrade contains metadata about the event,
+with fields that can be used to determine the chart version that was deployed:
+- `metadata.revision`: the Helm chart version deployed.
+- optional `metadata.oci-digest`: the OCI digest of the oci artifact deployed in
+  case of an `OCIRepository` source.
+
 Example of `.github/workflows/demo-promotion.yaml`:
 
 ```yaml

--- a/content/en/flux/use-cases/helm.md
+++ b/content/en/flux/use-cases/helm.md
@@ -66,7 +66,7 @@ Let's check out what the Custom Resource files look like:
 
 ```yaml
 # /flux/boot/traefik/helmrepo.yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: traefik
@@ -78,7 +78,7 @@ spec:
 
 ```yaml
 # /flux/boot/traefik/helmrelease.yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-traefik
@@ -177,10 +177,10 @@ documentation.
 ## Automatic Uninstalls and Rollback
 
 The Helm Controller offers an extensive set of configuration options to remediate when a Helm release fails,
-using [spec.install.remediation](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.InstallRemediation),
-[spec.upgrade.remediation](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.UpgradeRemediation),
-[spec.rollback](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Rollback)
-and [spec.uninstall](../components/helm/api/v2beta2#helm.toolkit.fluxcd.io/v2beta2.Uninstall).
+using [spec.install.remediation](../components/helm/api/v2#helm.toolkit.fluxcd.io/v2.InstallRemediation),
+[spec.upgrade.remediation](../components/helm/api/v2#helm.toolkit.fluxcd.io/v2.UpgradeRemediation),
+[spec.rollback](../components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Rollback)
+and [spec.uninstall](../components/helm/api/v2#helm.toolkit.fluxcd.io/v2.Uninstall).
 Features include the option to remediate with an uninstall after an upgrade failure,
 and the option to keep a failed release for debugging purposes when it has run out of retries.
 
@@ -188,7 +188,7 @@ Here is an example for configuring automated uninstalls (for all available field
 consult the `InstallRemediation` and `Uninstall` API references linked above):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release
@@ -213,7 +213,7 @@ Here is an example of automated rollback configuration (for all available fields
 consult the `UpgradeRemediation` and `Rollback` API references linked above):
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: my-release

--- a/content/en/flux/use-cases/karmada.md
+++ b/content/en/flux/use-cases/karmada.md
@@ -75,7 +75,7 @@ If you want to propagate Helm releases for your apps to member clusters, you can
 1. Define a Flux `HelmRepository` and a `HelmRelease` manifest in Karmada Control plane. They will serve as resource templates. 
 
 ```yaml
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo
@@ -83,7 +83,7 @@ spec:
   interval: 1m
   url: https://stefanprodan.github.io/podinfo  
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: podinfo
@@ -107,7 +107,7 @@ metadata:
   name: helm-repo
 spec:
   resourceSelectors:
-    - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    - apiVersion: source.toolkit.fluxcd.io/v1
       kind: HelmRepository
       name: podinfo
   placement:
@@ -122,7 +122,7 @@ metadata:
   name: helm-release
 spec:
   resourceSelectors:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta2
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: podinfo
   placement:
@@ -179,7 +179,7 @@ metadata:
   namespace: default
 spec:
   resourceSelectors:
-  - apiVersion: helm.toolkit.fluxcd.io/v2beta2
+  - apiVersion: helm.toolkit.fluxcd.io/v2
     kind: HelmRelease
     name: podinfo
   overrideRules:


### PR DESCRIPTION
Update documentation for Helm GA

- [x] move `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1` for `HelmChart` and `HelmRepository`
- [x] move `helm.toolkit.fluxcd.io/v2beta2` to `helm.toolkit.fluxcd.io/v2` for `Helmrelease`
- [x] document the usage of `.spec.chartRef`
- [x] update github promotion documentation

https://deploy-preview-1909--fluxcd.netlify.app/flux/guides/helmreleases/