### PR TITLE
Fix calendar timing - stale events hang around too long

### DIFF
--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -78,8 +78,10 @@ def read_calendar(cal):
     events = []
     gcal = Calendar.from_ical(cal)
     today = date.today()
+    now = datetime.now()
+    hour_ago = now - timedelta(hours=0, minutes=50)
     next_month = today+timedelta(days=30)
-    for event in recurring_ical_events.of(gcal).between(today, next_month):
+    for event in recurring_ical_events.of(gcal).between(hour_ago, next_month):
         description = replace_url_to_link(fix_double_url(event['description']))
         if type(event['dtstart'].dt) == date:
             event_time = datetime.combine(
@@ -100,7 +102,9 @@ def read_calendar(cal):
         }
         formatted_event.update(read_organizer(event))
 
-        events.append(formatted_event)
+        # Only include events that haven't started more than 1 hour ago
+        if event_time > pytz.utc.localize(hour_ago):
+            events.append(formatted_event)
 
     events.sort(key=lambda e: e['timestamp'])
     return events


### PR DESCRIPTION
Do not put events at the top of the calendar that started more than 1 hour ago

Today at 10:00 AM Eastern (GMT-4), April 17, the event from 16 hours ago Australia Edition finally dropped out of the list. That event was at 8:00 AM UTC+10 and it stayed in the list until the end of the day April 17, Brisbane time.

A bit not sure about why this happens, whether it's our code or the recurring ical events module that continues to include these events. It doesn't really matter if it's two minutes ago or an hour ago, up to 24 hours ago is too long, and I wanted to avoid "the event is actually starting now and the refresh job just ran, so it just dropped off the calendar, right as people are meant to be finding the link to join there." An hour seems like just long enough. The website only refreshes the calendar every 6 hours.

So if the event started more than 1 hour ago, it's stale and should not be listed anymore as a "next event" or "upcoming"

My plain naive reading of this code:

```python
for event in recurring_ical_events.of(gcal).between(today, next_month)
```
assumed that it could be easily refined to `between(now, next_month)` but it seems that doesn't work.

I'm sure that the intent of including events that started earlier today, whether it was our code or theirs, was to permit people time to find an event after it began already, but it really causes quite a lot of confusion from people who only read as far as "Next event:" and upon clicking through they found a date and time for some event that's already many hours in the past.