### PR TITLE
Move some of calendar to community.md page

### DIFF
--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -14,7 +14,7 @@ $('.calendar-list li').click(function() {
     static targets = [ "localtz" ];
     connect(){
       let tz_description = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      this.localtzTarget.innerHTML = `<b>now localized for ${tz_description}</b>`;
+      this.localtzTarget.innerHTML = `<b>localized for ${tz_description}</b>`;
     }
   })
 

--- a/assets/scss/blocks/_blocks.scss
+++ b/assets/scss/blocks/_blocks.scss
@@ -2,5 +2,6 @@
 @import "cncf";
 @import "hero";
 @import "calendar";
+@import "calendar_dark";
 @import "blog";
 @import "features";

--- a/assets/scss/blocks/_calendar_dark.scss
+++ b/assets/scss/blocks/_calendar_dark.scss
@@ -1,18 +1,18 @@
-.team-calendar {
-  padding: 0 0 1.5rem 1rem;
+.team-calendar-dark {
+  padding: 0 1rem 1.5rem 1rem;
   max-width: 740px;
-  // margin: 0 auto;
+  margin: 0 auto;
   @include media-breakpoint-down(sm) {
     overflow-x: hidden;
   }
 
   h3 {
     font-weight: 600;
-    text-align: left;
+    text-align: center;
   }
   p.caption, p.details {
-    text-align: left;
-    margin: 1rem 0 1rem 1rem;
+    text-align: center;
+    margin: 1rem 0 2rem 0;
   }
 
   p.details {
@@ -23,22 +23,22 @@
   ul.calendar-list {
     margin: 0 auto;
     list-style-type: none;
-    // @include media-breakpoint-down(sm) {
-    padding-left: 0;
-    // }
+    @include media-breakpoint-down(sm) {
+      padding-left: 0;
+    }
 
     & > li {
-      border-bottom: 1px solid rgba($flux-black, 0.25);
+      border-bottom: 1px solid rgba($flux-white, 0.25);
      
       .label {
-        text-decoration: underline 0.15em rgba($flux-black, 0);
+        text-decoration: underline 0.15em rgba($flux-white, 0);
         text-underline-offset: 0.2em;
         transition: text-decoration-color 300ms;
       }
 
       &:hover {
         .label {
-          text-decoration-color: rgba($flux-black, 0.75);
+          text-decoration-color: rgba($flux-white, 0.75);
           text-underline-offset: 0.2em;
           cursor: pointer;
         }
@@ -48,7 +48,7 @@
         border-bottom: none;
         .label {
           text-underline-offset: 0.2em;
-          text-decoration: underline 0.15em rgba($flux-black, 0.25);
+          text-decoration: underline 0.15em rgba($flux-white, 0.25);
         }
       }
 
@@ -61,7 +61,7 @@
         width: 6rem;
         text-align: left;
         font-weight: 500;
-        color:rgba($flux-black, 0.75);
+        color:rgba($flux-white, 0.75);
 
         padding: 6px 0;
 
@@ -75,7 +75,7 @@
         padding: 6px 0;
         padding-right: 2rem;
         font-weight: 300;
-        color:rgba($flux-black, 0.75);
+        color:rgba($flux-white, 0.75);
 
         vertical-align: bottom;
       }
@@ -121,7 +121,7 @@
       }
       
       dt {
-        color: rgba($flux-black, 0.75);
+        color: rgba($flux-white, 0.75);
         display: inline-block;
         width: 7.5rem;
         text-align: right;
@@ -130,7 +130,7 @@
       dd {
         margin: 0;
         padding-left: 14px;
-        color: rgba($flux-black, 1);
+        color: rgba($flux-white, 1);
         display: inline-block;
         clear: both;
       }

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -98,7 +98,7 @@ Announcing Flux 2.2 GA
 <!-- Community -->
 <div class="section-community">
   {{< blocks/section color="dark" type="calendar-row">}}
-  {{< home/calendar >}}
+  {{< home/calendar_dark >}}
   {{< /blocks/section >}}
 
   {{< blocks/lead color="dark" >}}

--- a/layouts/shortcodes/home/calendar.html
+++ b/layouts/shortcodes/home/calendar.html
@@ -1,39 +1,35 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
 <div class="team-calendar" data-controller="calendar">
-    <h3 id="calendar">Our Team Calendar</h3>
-    <p class="caption">The upcoming meetings, talks and community events in the next month are listed<br/>
-    below. (All times are <span data-calendar-target="localtz">UTC</span>.)</p>
-
-    <ul class="calendar-list">
-        {{ range $.Site.Data.calendar }}
-        <li>
-            <div class="calendar-row" data-controller="calrow">
-              <div class="date" data-calrow-target="date">{{ .date }}</div><span>&nbsp;</span>
-                <div class="time" data-calrow-target="time">{{ .time }}</div><span>&nbsp;</span>
-                <div class="origtz" aria-hidden="true" data-calrow-target="timestamp">{{ .timestamp }}</div> 
-                <div class="label">{{ .label }}</div>
-            </div>
-            <div class="calendar-card">
-                <ul class="details-list">
-                    <li>
-                        <dt>Where</dt>
-                        <dd>{{ .where }}</dd>
-                    </li>
-
-                    {{ if and .org_email .org_name }}
-                    <li>
-                        <dt>Organizer</dt>
-                        <dd><a href="mailto:{{ .org_email }}">{{ .org_name }}</a></dd>
-                    </li>
-                    {{ end }}
-                </ul>
-
-               <span class="description">{{ .description | safeHTML }}</span>
-            </div>
-        </li>
-        {{ end }}
-    </ul>
-
-    <p class="details">See <a href="/community/#meetings">this page</a>
-        for more detail and subscription options.</p>
+<h3 id="calendar">Our Team Calendar</h3>
+<p class="caption">The upcoming meetings, talks and community events in the next month are listed<br/>
+below. (All times are <span data-calendar-target="localtz">UTC</span>.)</p>
+<ul class="calendar-list">
+{{ range $.Site.Data.calendar }}
+<li>
+<div class="calendar-row" data-controller="calrow">
+<div class="date" data-calrow-target="date">{{ .date }}</div><span>&nbsp;</span>
+<div class="time" data-calrow-target="time">{{ .time }}</div><span>&nbsp;</span>
+<div class="origtz" aria-hidden="true" data-calrow-target="timestamp">{{ .timestamp }}</div> 
+<div class="label">{{ .label }}</div>
+</div>
+<div class="calendar-card">
+ <ul class="details-list">
+<li>
+<dt>Where</dt>
+<dd>{{ .where }}</dd>
+</li>
+{{ if and .org_email .org_name }}
+<li>
+<dt>Organizer</dt>
+<dd><a href="mailto:{{ .org_email }}">{{ .org_name }}</a></dd>
+</li>
+{{ end }}
+ </ul>
+<span class="description">{{ .description | safeHTML }}</span>
+</div>
+</li>
+{{ end }}
+</ul>
+<p class="details">See <a href="/community/#meetings">this page</a>
+    for more detail and subscription options.</p>
 </div>

--- a/layouts/shortcodes/home/calendar_dark.html
+++ b/layouts/shortcodes/home/calendar_dark.html
@@ -1,8 +1,9 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-<div class="team-calendar" data-controller="calendar">
+<div class="team-calendar-dark" data-controller="calendar">
+<h3 id="calendar">Our Team Calendar</h3>
 <p class="caption">Times shown are <span data-calendar-target="localtz">UTC</span>.</p>
 <ul class="calendar-list">
-{{ range $.Site.Data.calendar }}
+{{ range first 6 $.Site.Data.calendar }}
 <li>
 <div class="calendar-row" data-controller="calrow">
 <div class="date" data-calrow-target="date">{{ .date }}</div><span>&nbsp;</span>
@@ -28,4 +29,6 @@
 </li>
 {{ end }}
 </ul>
+<p class="details">See <a href="/community/#meetings">this page</a>
+    for more events, more details, and subscription options.</p>
 </div>


### PR DESCRIPTION
NOTE: Before this merges:

- [x] Rebase out or revert 294d423 - this is necessary to make preview-build work here,
        until fluxcd/community#396 merges

Check out the Deploy Preview here: https://deploy-preview-1940--fluxcd.netlify.app/
(note changes:
* Our Team Calendar: https://deploy-preview-1940--fluxcd.netlify.app/#calendar
* Community: https://deploy-preview-1940--fluxcd.netlify.app/community/#getting-involved)

These are the changes we discussed at the Flux Dev Meeting yesterday.

PR notes:

Let's reduce the amount of text and noise on the landing page, we only need to show the first few events.

In order to use the shortcode for the calendar in the external-imports, we need to avoid having parts of its HTML content converted into `<pre>` sections by the hugo builder.

It's an annoying change, but this is the only external-import with any shortcode that I'm aware of, and shortcodes aren't very big, so I think we can do without the indenting 🤷 

Some text changes and display formatting. The CSS rules to put the calendar into dark mode have been cloned and revised so the look of the table on the Community page is at least halfway decent. The calendar on the main page is now rendered by a `calendar_dark` shortcode, instead of the old `calendar` shortcode, but both are kept as I do not want to remove the calendar from the landing page yet. Just reduce its footprint.

(The preview has been made to work, even while fluxcd/community#396 hasn't merged)