### PR TITLE
Mark version 2.2 as archived and remove 2.0 from versions dropdown

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -105,16 +105,16 @@ params:
   offlineSearch: false
   version_menu: "Versions"
   version: "2.2"
-  archived_version: false
+  archived_version: true
   version_menu_pagelinks: true
   url_latest_version: https://fluxcd.io/flux/
   versions:
-    - version: "v2.2"
+    - version: "v2.3"
       url: https://fluxcd.io
+    - version: "v2.2"
+      url: https://v2-2.docs.fluxcd.io
     - version: "v2.1"
       url: https://v2-1.docs.fluxcd.io
-    - version: "v2.0"
-      url: https://v2-0.docs.fluxcd.io
   logos:
     navbar: flux-horizontal-white.png
     hero: flux-horizontal-color.png


### PR DESCRIPTION
We only support N-2 versions, that's 2.3, 2.2 and 2.1 so we shouldn't link to the 2.0 docs, anymore.