### PR TITLE
Update v2.1 version dropdown

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -101,12 +101,12 @@ params:
   version_menu_pagelinks: true
   url_latest_version: https://fluxcd.io/flux/
   versions:
-    - version: "v2.2"
+    - version: "v2.3"
       url: https://fluxcd.io
+    - version: "v2.2"
+      url: https://v2-2.docs.fluxcd.io
     - version: "v2.1"
       url: https://v2-1.docs.fluxcd.io
-    - version: "v2.0"
-      url: https://v2-0.docs.fluxcd.io
   logos:
     navbar: flux-horizontal-white.png
     hero: flux-horizontal-color.png


### PR DESCRIPTION
Latest release is 2.3, we only support N-2 versions, that's 2.3, 2.2 and 2.1 so we shouldn't link to the 2.0 docs, anymore.