### PR TITLE
Remove 2.0 from version dropdown

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -115,8 +115,6 @@ params:
       url: https://v2-2.docs.fluxcd.io
     - version: "v2.1"
       url: https://v2-1.docs.fluxcd.io
-    - version: "v2.0"
-      url: https://v2-0.docs.fluxcd.io
   logos:
     navbar: flux-horizontal-white.png
     hero: flux-horizontal-color.png


### PR DESCRIPTION
We only support N-2 versions, that's 2.3, 2.2 and 2.1 so we shouldn't link to the 2.0 docs, anymore.