### PR TITLE
Announce "Release 2.3" blog

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -66,8 +66,8 @@ features:
       all have great dashboards for you.
 ---
 
-{{% home/announce emoji="📢" url="/blog/2023/12/flux-v2.2.0/" %}}
-Announcing Flux 2.2 GA
+{{% home/announce emoji="📢" url="/blog/2024/05/flux-v2.3.0/" %}}
+Announcing Flux 2.3 GA
 {{% /home/announce %}}
 
 <div class="hero-gitops">


### PR DESCRIPTION
The Announce header on fluxcd.io main page can change to point at the new release blog, 🎉 