### PR TITLE
Add `winget` to CLI windows installation instructions

### DIFF
--- a/content/en/flux/cmd/_index.md
+++ b/content/en/flux/cmd/_index.md
@@ -51,6 +51,12 @@ With [Chocolatey](https://chocolatey.org/):
 choco install flux
 ```
 
+With [winget](https://github.com/microsoft/winget-cli) (only versions after 2.0.0):
+
+```sh
+winget install -e --id FluxCD.Flux
+```
+
 {{% /tab %}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
A couple of more ways are available to install FluxCLI on Windows. This commit improves the documentation adding the winget option and the direct download option.