### PR TITLE
chore: add cephcluster and clustersecretstore examples

### DIFF
--- a/content/en/flux/cheatsheets/cel-healthchecks.md
+++ b/content/en/flux/cheatsheets/cel-healthchecks.md
@@ -33,38 +33,73 @@ resource object itself.
 
 The items in this library are sorted in alphabetical order.
 
+### `CephCluster`
+
+The `CephCluster` resource in this example is created by the `rook-ceph-cluster` Flux `HelmRelease`.
+
+```yaml
+healthChecks:
+  - apiVersion: helm.toolkit.fluxcd.io/v2
+    kind: HelmRelease
+    name: rook-ceph-cluster
+    namespace: rook-ceph
+  - apiVersion: ceph.rook.io/v1
+    kind: CephCluster
+    name: rook-ceph
+    namespace: rook-ceph
+healthCheckExprs:
+  - apiVersion: ceph.rook.io/v1
+    kind: CephCluster
+    failed: status.ceph.health == 'HEALTH_ERR'
+    current: status.ceph.health == 'HEALTH_OK'
+```
+
 ### `Cluster`
 
 ```yaml
-- apiVersion: cluster.x-k8s.io/v1beta1
-  kind: Cluster
-  failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
-  current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+healthCheckExprs:
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    kind: Cluster
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
 ```
 
 ### `ClusterIssuer`
 
 ```yaml
-- apiVersion: cert-manager.io/v1
-  kind: ClusterIssuer
-  failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
-  current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+healthCheckExprs:
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+```
+
+### `ClusterSecretStore`
+
+```yaml
+healthCheckExprs:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ClusterSecretStore
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
 ```
 
 ### `ScaledObject`
 
 ```yaml
-- apiVersion: keda.sh/v1alpha1
-  kind: ScaledObject
-  failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
-  current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+healthCheckExprs:
+  - apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
 ```
 
 ### `SealedSecret`
 
 ```yaml
-- apiVersion: bitnami.com/v1alpha1
-  kind: SealedSecret
-  failed: status.conditions.filter(e, e.type == 'Synced').all(e, e.status == 'False')
-  current: status.conditions.filter(e, e.type == 'Synced').all(e, e.status == 'True')
+healthCheckExprs:
+  - apiVersion: bitnami.com/v1alpha1
+    kind: SealedSecret
+    failed: status.conditions.filter(e, e.type == 'Synced').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Synced').all(e, e.status == 'True')
 ```


### PR DESCRIPTION
Hi 👋🏼 

I added examples for cephcluster and clustersecretstore. I also updated the examples to include `healthCheckExprs` in all for consistency.

## cephcluster verification

```yaml
# k get cephcluster -n rook-ceph rook-ceph -oyaml | yq .status
ceph:
  capacity:
    bytesAvailable: 2047502884864
    bytesTotal: 2400498229248
    bytesUsed: 352995344384
    lastUpdated: "2025-02-21T13:17:48Z"
  fsid: ea343e3b-e0b6-402d-9eb0-3dfe7be41b27
  health: HEALTH_OK
  lastChanged: "2025-02-20T22:19:32Z"
  lastChecked: "2025-02-21T13:17:48Z"
  previousHealth: HEALTH_WARN
  versions:
    mds:
      ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 2
    mgr:
      ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 2
    mon:
      ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 3
    osd:
      ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 3
    overall:
      ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 12
    rgw:
      ceph version 19.2.1 (58a7fab8be0a062d730ad7da874972fd3fba59fb) squid (stable): 2
conditions:
  - lastHeartbeatTime: "2025-02-21T13:17:49Z"
    lastTransitionTime: "2024-12-18T04:13:28Z"
    message: Cluster created successfully
    reason: ClusterCreated
    status: "True"
    type: Ready
message: Cluster created successfully
observedGeneration: 9
phase: Ready
state: Created
storage:
  deviceClasses:
    - name: nvme
  osd:
    migrationStatus: {}
    storeType:
      bluestore: 3
version:
  image: quay.io/ceph/ceph:v19.2.1
  version: 19.2.1-0
```

## clustersecretstore

```yaml
# k get clustersecretstore onepassword -oyaml | yq .status
capabilities: ReadOnly
conditions:
  - lastTransitionTime: "2025-02-13T21:52:46Z"
    message: store validated
    reason: Valid
    status: "True"
    type: Ready
```