### PR TITLE
Add a note on Forgejo support

### DIFF
--- a/content/en/flux/installation/bootstrap/gitea.md
+++ b/content/en/flux/installation/bootstrap/gitea.md
@@ -19,6 +19,11 @@ It is also required that the person running the command to be the **owner** of t
 or to have admin rights of a Gitea organization.
 {{% /alert %}}
 
+{{% alert color="info" title="Forgejo support" %}}
+Forgejo is a fork of Gitea (see their [Comparison with Gitea](https://forgejo.org/compare-to-gitea/)).
+Given that Forgejo is mainly backward compatible with Gitea, you can use the same commands that you use for Gitea and it will work.
+{{% /alert %}}
+
 ## Gitea PAT
 
 For accessing the Gitea API, the boostrap command requires a Gitea personal access token (PAT)


### PR DESCRIPTION
Forgejo is a fork of Gitea (see their [Comparison with Gitea](https://forgejo.org/compare-to-gitea/)).

I found [this discussion on the main flux repo](https://github.com/fluxcd/flux2/discussions/4924) and wanted to know if the gitea boostrap command works with Forgejo. I've described what I've done in a blog post titled [Flux and Forgejo](https://oligot.be/posts/flux-forgejo/) if you are interested but in a nutshell, you can use the exact same commands with a Forgejo server and it works !

This adds a small note on the gitea boostrap page to let people know that they can use Forgejo instead of Gitea with Flux.