### PR TITLE
Update website cron job for Flux 2.5

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - name: Deploy current production branch on Netlify
         run: |
-          curl -X POST -d {} '${{ secrets.NETLIFY_BUILD_HOOK }}?trigger_branch=v2-4'
+          curl -X POST -d {} '${{ secrets.NETLIFY_BUILD_HOOK }}?trigger_branch=v2-5'


### PR DESCRIPTION
I noticed after the Flux Bug Scrub last night, the website did not update this A.M.

It looks like we still have to update this workflow for each new minor/major release, to change the trigger branch.