### PR TITLE
Add Crossplane example to Flux custom health checks

### DIFF
--- a/content/en/flux/cheatsheets/cel-healthchecks.md
+++ b/content/en/flux/cheatsheets/cel-healthchecks.md
@@ -84,6 +84,20 @@ healthCheckExprs:
     current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
 ```
 
+### `Crossplane`
+
+```yaml
+healthCheckExprs:
+  - apiVersion: pkg.crossplane.io/v1
+    kind: Provider
+    failed: status.conditions.filter(e, e.type == 'Healthy').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Healthy').all(e, e.status == 'True')
+  - apiVersion: iam.aws.crossplane.io/v1beta1
+    kind: Role
+    failed: status.conditions.filter(e, e.type == 'Synced').all(e, e.status == 'False' && e.reason == 'ReconcileError')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+```
+
 ### `ScaledObject`
 
 ```yaml


### PR DESCRIPTION
Crossplane custom resources lack `.status. observedGeneration` nor do they have an `observedGeneration` field on the their status conditions which makes it impossible to determine if the desired state from `.spec` is in sync with the actual state. 

The custom health check added here, will make Flux wait for a Crossplane resource to be reconcile at **creation time**, but during updates, the health check is subject to race conditions because it's not possible to know if the new resource generation was acknowledged by a Crossplane controller. Given the fact that Flux runs the health checks on a schedule, if the Crossplane resource update fails at a later time, Flux will correctly report the error. 

