### PR TITLE
Update _index.md

### DIFF
--- a/content/en/flagger/_index.md
+++ b/content/en/flagger/_index.md
@@ -7,7 +7,7 @@ cascade:
 ---
 
 [Flagger](https://github.com/fluxcd/flagger) is a progressive delivery tool that automates the release
-process for applications running on Kubernetes. It reduces the risk of introducing a new software
+process for applications running on Kubernetes. It reduces the risk associated with introducing a new software
 version in production by gradually shifting traffic to the new version while measuring metrics
 and running conformance tests.
 


### PR DESCRIPTION
Clarified a sentence.

The original sentence implied that new software versions should be avoided.
Hopefully, the proposed wording explains that the mitigation takes place in the rollout of new version, and not in avoiding software changes.