### PR TITLE
Fix GitHub Action syntax error and filter with if statement

### DIFF
--- a/content/en/flux/use-cases/gh-actions-auto-pr.md
+++ b/content/en/flux/use-cases/gh-actions-auto-pr.md
@@ -33,11 +33,13 @@ To create the pull request whenever automation creates a new branch, in your man
 name: Staging Auto-PR
 on:
   create:
-    branches: [staging]
 
 jobs:
   pull-request:
     runs-on: ubuntu-latest
+    if: |
+      github.event.ref_type == 'branch' &&
+      github.event.ref == 'staging'
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
`create` events cannot be filtered with `branches`. `branches` be will silently ignored and match all create events.

See:
- https://docs.github.com/en/webhooks/webhook-events-and-payloads#create
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#create
- https://github.com/orgs/community/discussions/26286