### PR TITLE
Add RBAC patch to remove Object-level Workload Identity

### DIFF
--- a/content/en/flux/installation/configuration/multitenancy.md
+++ b/content/en/flux/installation/configuration/multitenancy.md
@@ -157,3 +157,40 @@ patches:
       kind: ClusterRole
       name: "(flux-view|flux-edit)-flux-system"
 ```
+
+### Flux Object-level Workload Identity RBAC
+
+Starting with v2.6, Flux supports object-level workload identity, which requires
+additional RBAC permissions to be granted to the controllers so that they can create `ServiceAccount` tokens:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-controller
+rules:
+  # excerpt from the existing rules
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+```
+
+If you wish to disable the object-level workload identity RBAC in Flux 2.6 or later, you can do so with the following patch:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gotk-components.yaml
+  - gotk-sync.yaml
+patches:
+  - patch: |
+      - op: remove
+        path: /rules/10
+    target:
+      kind: ClusterRole
+      name: "crd-controller-flux-system"
+```

--- a/content/en/flux/security/_index.md
+++ b/content/en/flux/security/_index.md
@@ -177,6 +177,7 @@ These include:
     - Can get, list, and watch namespaces and secrets
     - Can get, list, watch, create, patch, and delete configmaps and their status
     - Can get, list, watch, create, patch, and delete coordination.k8s.io leases
+    - Can create ServiceAccount tokens used for object-level workload identity
 2. A `crd-controller` `ClusterRoleBinding`:
     - References `crd-controller` `ClusterRole` above
     - Bound to a service accounts for every Flux controller


### PR DESCRIPTION
Add `Object-level Workload Identity RBAC` section to multi-tenancy docs with an example of how to disable the extra RBAC.