### PR TITLE
Promote OCI Repository and Bucket API to v1

### DIFF
--- a/content/en/flux/gitops-toolkit/packages.md
+++ b/content/en/flux/gitops-toolkit/packages.md
@@ -42,8 +42,8 @@ API Types
 | [GitRepository](/flux/components/source/gitrepositories/)   | v1      |
 | [HelmRepository](/flux/components/source/helmrepositories/) | v1      |
 | [HelmChart](/flux/components/source/helmcharts.md)          | v1      |
-| [Bucket](/flux/components/source/buckets.md)                | v1beta2 |
 | [OCIRepository](/flux/components/source/ocirepositories/)   | v1      |
+| [Bucket](/flux/components/source/buckets.md)                | v1      |
 
 ### kustomize.toolkit.fluxcd.io
 

--- a/content/en/flux/gitops-toolkit/packages.md
+++ b/content/en/flux/gitops-toolkit/packages.md
@@ -35,12 +35,6 @@ Import package
 import sourcev1 "github.com/fluxcd/source-controller/api/v1"
 ```
 
-and for `OCIRepository` objects:
-
-```go
-import sourcev1b2 "github.com/fluxcd/notification-controller/api/v1beta2"
-```
-
 API Types
 
 | Name                                                        | Version |
@@ -48,8 +42,8 @@ API Types
 | [GitRepository](/flux/components/source/gitrepositories/)   | v1      |
 | [HelmRepository](/flux/components/source/helmrepositories/) | v1      |
 | [HelmChart](/flux/components/source/helmcharts.md)          | v1      |
-| [OCIRepository](/flux/components/source/ocirepositories/)   | v1beta2 |
 | [Bucket](/flux/components/source/buckets.md)                | v1beta2 |
+| [OCIRepository](/flux/components/source/ocirepositories/)   | v1      |
 
 ### kustomize.toolkit.fluxcd.io
 


### PR DESCRIPTION
* [Promote OCI Repository API to v1](https://github.com/fluxcd/website/commit/bcfc8eeffc6a4f8dad9d91953738d5a356bf6546)
* [Promote Bucket API to v1](https://github.com/fluxcd/website/commit/f5542eba7f7391fc52b37ba01c1f24c70e303725)