### PR TITLE
Update Roadmap

### DIFF
--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -103,12 +103,12 @@ metadata:
   namespace: default
 spec:
   interval: 10m
+  url: oci://ghcr.io/stefanprodan/charts/podinfo
   layerSelector:
     mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
     operation: copy
-  url: oci://ghcr.io/stefanprodan/charts/podinfo
   ref:
-    semver: ">=6.5.0"
+    semver: ">=6.9.0"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/content/en/flux/guides/helmreleases.md
+++ b/content/en/flux/guides/helmreleases.md
@@ -171,8 +171,11 @@ metadata:
 spec:
   interval: 5m0s
   url: oci://ghcr.io/stefanprodan/charts/podinfo
+  layerSelector:
+    mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
+    operation: copy
   ref:
-    semver: "^6.5.0"
+    semver: "^6.9.0"
 ```
 
 The source-controller will fetch the Helm chart from the OCI registry namespace 
@@ -184,6 +187,8 @@ value means newer chart versions will be detected at a slower pace,
 a push-based fetch can be introduced using [webhook receivers](webhook-receivers.md).
 
 The `url` has to point to a registry repository and start with prefix `oci://`.
+
+The `layerSelector` has to be set to select the Helm chart content layer.
 
 The `ref` defines the checkout strategy, and can be one of `tag`, `digest` or `semver`.
 When using `semver`, an optional `semverFilter` can be provided to filter the tags.

--- a/content/en/roadmap.md
+++ b/content/en/roadmap.md
@@ -115,7 +115,7 @@ and add support for object-level workload identity authentication for container 
 **Status**: In Progress
 
 The primary goal of this milestone is to make a generally available release for the Flux image automation APIs,
-and make Flux server-side apply compatible with Kubernetes Vertical Pod Autoscaler (VPA).
+and make Flux watch for changes in ConfigMaps and Secrets referenced in Kustomizations and HelmReleases.
 
 - **Image automation**
   - [ ] Promote the `ImageUpdateAutomation` API to `v1`
@@ -129,7 +129,6 @@ and make Flux server-side apply compatible with Kubernetes Vertical Pod Autoscal
   - [x] [Add support for remote cluster authentication using Workload Identity](https://github.com/fluxcd/kustomize-controller/pull/1476)
   - [x] [Watch ConfigMaps and Secrets referenced in Kustomizations](https://github.com/fluxcd/flux2/issues/5446)
   - [x] [Extend the readiness evaluation of dependencies with CEL expressions](https://github.com/fluxcd/kustomize-controller/pull/1491)
-  - [ ] [Extend `ssa.Apply` with field ignore rules](https://github.com/fluxcd/pkg/issues/696)
 
 - **Helm integrations**
   - [x] [Extend HelmRelease post-renderer with CommonMetadata](https://github.com/fluxcd/helm-controller/pull/1223)


### PR DESCRIPTION
Update goal for the v2.7 milestone. 

In addition, this PR adds the missing `layerSelector` to the Helm guide.