### PR TITLE
Fix left sidebar to use full height (#2136)

### DIFF
--- a/assets/scss/blocks/_nav.scss
+++ b/assets/scss/blocks/_nav.scss
@@ -83,4 +83,9 @@ nav.navbar {
     color: $gray-900;
     font-weight: unset;
   }
+  // fix the scroll height of the sidebar
+  @media (min-width: 768px) {
+    max-height: calc(100vh - 5rem);
+    overflow-y: auto;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "website",
+  "name": "site",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "site",
+  "name": "website",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
closes #2136 
<img width="1906" height="957" alt="image" src="https://github.com/user-attachments/assets/2385aa3a-998e-4308-84f2-eebe2ed7e127" />
If applied, this commit will ensure that the sidebar takes full available height while maintaining the scroll so that its obvious there is more content below