### PR TITLE
docs: fix indentation in custom metrics example

### DIFF
--- a/content/en/flux/monitoring/custom-metrics.md
+++ b/content/en/flux/monitoring/custom-metrics.md
@@ -57,8 +57,8 @@ called `gotk_resource_info` with labels `name`, `exported_namespace`,
   each:
     type: Info
     info:
-    labelsFromPath:
-      name: [metadata, name]
+      labelsFromPath:
+        name: [metadata, name]
   labelsFromPath:
     exported_namespace: [metadata, namespace]
     suspended: [spec, suspend]


### PR DESCRIPTION
Makes the `each.info` indentation of the first example same as the 2nd one:

https://github.com/fluxcd/website/blob/77178b1ac77dfc9c02edab7b5f1da3450ffb40cd/content/en/flux/monitoring/custom-metrics.md#L92-L95