### PR TITLE
roadmap: Mark the 2.7 milestone as completed

### DIFF
--- a/content/en/flux/components/_index.md
+++ b/content/en/flux/components/_index.md
@@ -25,7 +25,7 @@ guide](../gitops-toolkit/source-watcher/) is a good place to start.
 
 A reference for each component and API type is linked below.
 
-- [Source Controller](source/_index.md)
+- [Source Controllers](source/_index.md)
     - [GitRepository CRD](source/gitrepositories.md)
     - [OCIRepository CRD](source/ocirepositories.md)
     - [HelmRepository CRD](source/helmrepositories.md)

--- a/content/en/flux/installation/_index.md
+++ b/content/en/flux/installation/_index.md
@@ -23,7 +23,7 @@ The Kubernetes cluster should match one of the following versions:
 |--------------------|------------------|
 | `v1.32`            | `>= 1.32.0`      |
 | `v1.33`            | `>= 1.33.0`      |
-| `v1.34` and later  | `>= 1.34.0`      |
+| `v1.34` and later  | `>= 1.34.1`      |
 
 {{% alert color="info" title="Kubernetes EOL" %}}
 Note that Flux may work on older versions of Kubernetes e.g. 1.30,

--- a/content/en/flux/installation/configuration/optional-components.md
+++ b/content/en/flux/installation/configuration/optional-components.md
@@ -32,6 +32,15 @@ flux bootstrap git \
   --components-extra image-reflector-controller,image-automation-controller
 ```
 
+To enable the Flux source composition and decomposition features,
+the [source-watcher](https://github.com/fluxcd/source-watcher) component
+can be added to the extra components.
+
+```shell
+flux bootstrap git \
+  --components-extra source-watcher
+```
+
 By default, both `flux bootstrap` and `flux install` commands do not include any extra components.
 
 ## Network policies

--- a/content/en/roadmap.md
+++ b/content/en/roadmap.md
@@ -112,7 +112,7 @@ and add support for object-level workload identity authentication for container 
 
 ### v2.7 (Q3 2025)
 
-**Status**: In Progress
+**Status**: Completed on 2025-09-30 (v2.7.0 [changelog](https://fluxcd.io/blog/2025/05/flux-v2.7.0/))
 
 The primary goal of this milestone is to make a generally available release for the Flux image automation APIs,
 and make Flux watch for changes in ConfigMaps and Secrets referenced in Kustomizations and HelmReleases.
@@ -213,6 +213,10 @@ and to extend Flux server-side apply with field ignore rules.
 - **EOL and Deprecations**
   - End support for Flux v2.5.x
   - End support for Kubernetes v1.32.x
+  - Remove deprecated APIs in group `source.toolkit.fluxcd.io/v1beta2`
+  - Remove deprecated APIs in group `kustomize.toolkit.fluxcd.io/v1beta2`
+  - Remove deprecated APIs in group `helm.toolkit.fluxcd.io/v2beta2`
+  - Remove deprecated APIs in group `notification.toolkit.fluxcd.io/v1beta2`
 
 ## Request for comments
 


### PR DESCRIPTION
Also added the removal of deprecated APIs in 2.8