### PR TITLE
Link to the KubeCon page from `home/announce`

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -66,8 +66,8 @@ features:
       all have great dashboards for you.
 ---
 
-{{% home/announce emoji="📢" url="/blog/2025/09/flux-v2.7.0/" %}}
-Announcing Flux 2.7 GA
+{{% home/announce emoji="📢" url="/kubecon/" %}}
+Flux at KubeCon NA
 {{% /home/announce %}}
 
 <div class="hero-gitops">


### PR DESCRIPTION
https://fluxcd.io/kubecon