### PR TITLE
Style & UX improvements for resources (limit to 3, truncate titles, open videos in new tab)

### DIFF
--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -64,7 +64,7 @@ main.td-main {
     p.next-event {
       padding-bottom: 45px;
       padding-top: 20px;
-      font-size: 32px;
+      font-size: 24px;
       span.origtz {
         display: none;
       }

--- a/assets/scss/_index.scss
+++ b/assets/scss/_index.scss
@@ -85,7 +85,12 @@ main.td-main {
     color: $flux-white;
     font-size: 1.25rem;
     font-weight: 600;
-    margin: 0.85rem 0;
+    margin: 0.85rem 0 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   img {
@@ -93,7 +98,9 @@ main.td-main {
   }
  
   .col-lg-4 {
+    position: relative;
     padding: 0 2rem !important;
+    padding-bottom: 3.25rem !important;
   }
 }
 

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -156,6 +156,8 @@
             : doc.url
             ? doc.url
             : "";
+          element.querySelector(".thumbnail-link").target = "_blank";
+          element.querySelector(".thumbnail-link").rel = "noopener noreferrer";
           element.querySelector(".img-thumbnail").src = doc.youtube
             ? `https://i3.ytimg.com/vi/${doc.youtube}/0.jpg`
             : doc.thumbnail
@@ -167,6 +169,8 @@
             : doc.url
             ? doc.url
             : "";
+          element.querySelector(".resource-title-link").target = "_blank";
+          element.querySelector(".resource-title-link").rel = "noopener noreferrer";
           element.querySelector(".resource-title-heading").textContent =
             doc.title;
           element.querySelector(".tag").textContent = doc.type;

--- a/layouts/partials/resource.html
+++ b/layouts/partials/resource.html
@@ -19,8 +19,8 @@
 {{ $dateTime := $t.Format $format }} 
 
 <div class="col-lg-4 mb-3 mb-lg-0 ">
-  <a href="{{ $url }}"><img class="img-fluid img-thumbnail" alt="{{ $title | markdownify }}" src="{{ $thumbnail }}"></a>
-  <a href="{{ $url }}"><h4>{{ $title | markdownify }}</h4></a>
+  <a href="{{ $url }}" target="_blank" rel="noopener noreferrer"><img class="img-fluid img-thumbnail" alt="{{ $title | markdownify }}" src="{{ $thumbnail }}"></a>
+  <a href="{{ $url }}" target="_blank" rel="noopener noreferrer"><h4>{{ $title | markdownify }}</h4></a>
   <span class="tag1 tag">
     {{ .type }}
 </span>
@@ -32,8 +32,8 @@
 
 <template id="search-result" hidden>
 <div class="col-lg-4 mb-3 mb-lg-0 col-hidden">
-  <a href="" class="thumbnail-link"><img class="img-fluid img-thumbnail" alt="" src=""></a>
-  <a href="" class="resource-title-link"><h4 class="resource-title-heading"></h4></a>
+  <a href="" class="thumbnail-link" target="_blank" rel="noopener noreferrer"><img class="img-fluid img-thumbnail" alt="" src=""></a>
+  <a href="" class="resource-title-link" target="_blank" rel="noopener noreferrer"><h4 class="resource-title-heading"></h4></a>
   <span class="tag1 tag">
 </span>
 <label class="date"></label>

--- a/layouts/partials/template-resource.html
+++ b/layouts/partials/template-resource.html
@@ -1,7 +1,7 @@
 <template id="search-result" hidden>
 <div class="col-lg-4 mb-3 mb-lg-0 col-hidden">
-  <a href="" class="thumbnail-link"><img class="img-fluid img-thumbnail" alt="" src=""></a>
-  <a href="" class="resource-title-link"><h4 class="resource-title-heading"></h4></a>
+  <a href="" class="thumbnail-link" target="_blank" rel="noopener noreferrer"><img class="img-fluid img-thumbnail" alt="" src=""></a>
+  <a href="" class="resource-title-link" target="_blank" rel="noopener noreferrer"><h4 class="resource-title-heading"></h4></a>
   <span class="tag1 tag">
 </span>
 <label class="date"></label>

--- a/layouts/shortcodes/home/resources_section.html
+++ b/layouts/shortcodes/home/resources_section.html
@@ -1,5 +1,5 @@
-{{ $resources := $.Site.Data.resources.resources }}
+{{ $resources := sort $.Site.Data.resources.resources "date" "desc" }}
 
-{{ range first 3 (where $resources "description" "!=" nil) }}
+{{ range first 3 $resources }}
     {{ partial "resource.html" . }}
 {{ end }}


### PR DESCRIPTION
PR: Improve resource styling and UX behavior
- Fix styling issues for resource components
- Always display the latest 3 resources
- Limit resource titles (h4) to a maximum of 3 lines
- Open video links in a new window to prevent navigation away from the Flux website