### PR TITLE
ArtifactGenerator use cases

### DIFF
--- a/content/en/flux/flux-e2e.md
+++ b/content/en/flux/flux-e2e.md
@@ -5,10 +5,8 @@ description: "A narrative of the life of a commit as it relates to Flux componen
 weight: 146
 ---
 
-{{% alert color="warning" title="Disclaimer" %}}
-Note that this guide has not been updated since more than a year ago. It does not address `OCIRepository`, needs review in consideration of Flux v2.0.0, and likely needs to be refreshed.
-
-Expect this doc to receive an overhaul soon.
+{{% alert color="info" title="Updated" %}}
+This guide was updated for Flux v2.7 and now covers `ArtifactGenerator` use cases for monorepo decomposition and Helm chart composition from multiple sources.
 {{% /alert %}}
 
 Below we describe the flow of data through Flux, from End to End.
@@ -151,6 +149,8 @@ A brief outline of the life cycle of a change as it's processed through Flux, ce
 14. [Channel-based Providers for Notifications][] re-publish `Events` from Flux resources at-large to a channel where users can see them.
 15. [Git Commit Status Provider Notifications][] re-publish `Events` from the Kustomize Controller as commit checks.
 16. [Waiting and Health Checking for Flux Kustomization][].
+17. [ArtifactGenerator for Monorepo Decomposition][] splits a single source into independent deployment artifacts.
+18. [ArtifactGenerator for Helm Chart Composition][] composes a Helm chart from multiple sources with merged values.
 
 ### Bootstrapping Flux
 
@@ -577,6 +577,262 @@ marked as ready.
 
 The health checking feature is called [Health Checks][] in the Flux Kustomization API.
 
+### ArtifactGenerator for Monorepo Decomposition
+
+In many organizations, a single Git monorepo contains deployment manifests for multiple independent services.
+Without `ArtifactGenerator`, the entire monorepo artifact is pulled and reconciled by every `Kustomization` that
+references it, even when only a single service's manifests have changed. This can cause unnecessary reconciliation
+cycles across all services.
+
+The [ArtifactGenerator][] (part of the [source-watcher][] extension) solves this by decomposing a single `GitRepository`
+source into multiple independent `ExternalArtifact` resources. Each artifact has its own content-based revision, so
+when a change is pushed to the monorepo, only the artifacts whose content actually changed will receive new revisions,
+triggering only the downstream `Kustomizations` that apply them.
+
+Consider a monorepo with the following structure:
+
+```text
+my-monorepo/
+├── deploy/
+│   ├── frontend/
+│   │   ├── deployment.yaml
+│   │   └── service.yaml
+│   └── backend/
+│       ├── deployment.yaml
+│       ├── service.yaml
+│       └── configmap.yaml
+└── ...
+```
+
+First, define a `GitRepository` source for the monorepo:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: my-monorepo
+  namespace: apps
+spec:
+  interval: 5m
+  url: https://github.com/example/my-monorepo
+  ref:
+    branch: main
+```
+
+Then create an `ArtifactGenerator` that splits the monorepo into two independent artifacts:
+
+```yaml
+apiVersion: source.extensions.fluxcd.io/v1beta1
+kind: ArtifactGenerator
+metadata:
+  name: my-app
+  namespace: apps
+spec:
+  sources:
+    - alias: repo
+      kind: GitRepository
+      name: my-monorepo
+  artifacts:
+    - name: frontend
+      copy:
+        - from: "@repo/deploy/frontend/**"
+          to: "@artifact/"
+    - name: backend
+      copy:
+        - from: "@repo/deploy/backend/**"
+          to: "@artifact/"
+```
+
+The controller generates two `ExternalArtifact` resources (`frontend` and `backend`), each containing
+only the manifests from the corresponding subdirectory. The artifact revision is computed from the
+SHA256 digest of the final content, in the format `latest@sha256:<hash>`.
+
+Deploy each artifact independently using Flux `Kustomizations`:
+
+```yaml
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: backend
+  namespace: apps
+spec:
+  interval: 30m
+  sourceRef:
+    kind: ExternalArtifact
+    name: backend
+  path: "./"
+  prune: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: frontend
+  namespace: apps
+spec:
+  interval: 30m
+  sourceRef:
+    kind: ExternalArtifact
+    name: frontend
+  path: "./"
+  prune: true
+```
+
+When a developer pushes a change to `deploy/frontend/deployment.yaml`, only the `frontend` artifact
+receives a new revision. The `backend` artifact digest remains unchanged, so its `Kustomization` does
+not reconcile. This selective reconciliation reduces cluster load and avoids unnecessary rollouts.
+
+{{% alert color="info" title="Feature gate" %}}
+Consumption of `ExternalArtifact` resources by `kustomize-controller` and `helm-controller` requires
+the `ExternalArtifact=true` feature gate on each controller.
+{{% /alert %}}
+
+#### Diagram: Monorepo decomposition with ArtifactGenerator
+
+```mermaid
+sequenceDiagram
+    actor me
+    participant git as Git<br><br>monorepo
+    participant sc as Flux<br><br>source-controller
+    participant ag as ArtifactGenerator<br><br>controller
+    participant kc as Flux<br><br>kustomize-controller
+    participant kube as Kubernetes<br><br>api-server
+    me->>git: 1. git push (change deploy/frontend/)
+    sc->>git: 2. git pull
+    sc->>sc: 3. build artifact for revision
+    sc->>kube: 4. update GitRepository status
+    kube->>ag: 5. notify about new revision
+    ag->>sc: 6. fetch source artifact
+    ag->>ag: 7. split into frontend + backend
+    ag->>ag: 8. compute content digests
+    ag->>kube: 9. update ExternalArtifact (frontend only)
+    Note over ag,kube: backend digest unchanged — no update
+    kube->>kc: 10. notify about frontend revision
+    kc->>ag: 11. fetch frontend artifact
+    kc->>kube: 12. apply frontend manifests
+    kc->>kube: 13. update Kustomization status
+```
+
+### ArtifactGenerator for Helm Chart Composition
+
+A common operational pattern is to store a Helm chart in an OCI registry but manage environment-specific
+`values.yaml` overrides in a Git repository. Traditionally, this requires either duplicating the chart,
+using `HelmRelease.spec.valuesFrom`, or maintaining complex CI pipelines to merge values before deployment.
+
+The `ArtifactGenerator` simplifies this by composing a single `ExternalArtifact` from multiple sources:
+the chart from an `OCIRepository` and the override values from a `GitRepository`. The `Merge` copy strategy
+performs a Helm-compatible deep merge of YAML values, so the resulting artifact contains the chart with
+the merged `values.yaml` ready for deployment.
+
+Define the sources:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: podinfo-chart
+  namespace: apps
+spec:
+  interval: 10m
+  url: oci://ghcr.io/stefanprodan/charts/podinfo
+  ref:
+    semver: ">=6.0.0"
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: podinfo-values
+  namespace: apps
+spec:
+  interval: 5m
+  url: https://github.com/example/fleet-config
+  ref:
+    branch: main
+```
+
+Create an `ArtifactGenerator` that composes the chart with environment-specific values:
+
+```yaml
+apiVersion: source.extensions.fluxcd.io/v1beta1
+kind: ArtifactGenerator
+metadata:
+  name: podinfo
+  namespace: apps
+spec:
+  sources:
+    - alias: chart
+      kind: OCIRepository
+      name: podinfo-chart
+      namespace: apps
+    - alias: repo
+      kind: GitRepository
+      name: podinfo-values
+      namespace: apps
+  artifacts:
+    - name: podinfo-composite
+      originRevision: "@chart"
+      copy:
+        - from: "@chart/"
+          to: "@artifact/"
+        - from: "@repo/charts/podinfo/values-prod.yaml"
+          to: "@artifact/podinfo/values.yaml"
+          strategy: Merge
+```
+
+The `originRevision: "@chart"` field instructs the controller to inherit the OCI artifact's origin
+revision metadata (such as the Git commit SHA from which the chart was built) and set it as the
+`org.opencontainers.image.revision` annotation on the generated `ExternalArtifact`.
+
+The `strategy: Merge` on the second copy operation performs a Helm-compatible deep merge:
+the base `values.yaml` from the chart is merged with `values-prod.yaml` from Git, with the
+Git values taking precedence. Arrays are replaced entirely, matching Helm's native merge behavior.
+
+Deploy the composed chart using a `HelmRelease`:
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: apps
+spec:
+  interval: 10m
+  releaseName: podinfo
+  chartRef:
+    kind: ExternalArtifact
+    name: podinfo-composite
+```
+
+Whenever either source changes — a new chart version is published to the OCI registry, or the
+values file is updated in Git — the `ArtifactGenerator` produces a new composite artifact with a
+new content-based revision, and the `HelmRelease` automatically performs an upgrade.
+
+#### Diagram: Helm chart composition with ArtifactGenerator
+
+```mermaid
+sequenceDiagram
+    actor me
+    participant oci as OCI<br><br>registry
+    participant git as Git<br><br>repository
+    participant sc as Flux<br><br>source-controller
+    participant ag as ArtifactGenerator<br><br>controller
+    participant hc as Flux<br><br>helm-controller
+    participant kube as Kubernetes<br><br>api-server
+    me->>git: 1. push values-prod.yaml
+    sc->>git: 2. git pull
+    sc->>oci: 3. pull chart
+    sc->>kube: 4. update source status
+    kube->>ag: 5. notify about source change
+    ag->>sc: 6. fetch chart + values artifacts
+    ag->>ag: 7. deep merge values.yaml
+    ag->>ag: 8. package composite artifact
+    ag->>kube: 9. update ExternalArtifact status
+    kube->>hc: 10. notify about new revision
+    hc->>ag: 11. fetch composite chart
+    hc->>kube: 12. helm upgrade
+    hc->>kube: 13. update HelmRelease status
+```
+
 [Bootstrapping Flux]: #bootstrapping-flux
 [Generating a Flux resource]: #generating-a-flux-resource
 [Previewing changes]: #previewing-changes
@@ -594,6 +850,8 @@ The health checking feature is called [Health Checks][] in the Flux Kustomizatio
 [Channel-based Providers for Notifications]: #channel-based-providers-for-notifications
 [Git Commit Status Provider Notifications]: #git-commit-status-provider-notifications
 [Waiting and Health Checking for Flux Kustomization]: #waiting-and-health-checking-for-flux-kustomization
+[ArtifactGenerator for Monorepo Decomposition]: #artifactgenerator-for-monorepo-decomposition
+[ArtifactGenerator for Helm Chart Composition]: #artifactgenerator-for-helm-chart-composition
 
 [GitOps toolkit]: /flux/components/
 [Security]: /flux/security/
@@ -627,3 +885,5 @@ The health checking feature is called [Health Checks][] in the Flux Kustomizatio
 [Event API]: /flux/components/notification/event/
 [Setup Git Commit Status Notications]: /flux/guides/notifications/#git-commit-status
 [Health Checks]: /flux/components/kustomize/kustomizations/#health-checks
+[ArtifactGenerator]: https://github.com/fluxcd/source-watcher/tree/v2
+[source-watcher]: https://github.com/fluxcd/source-watcher


### PR DESCRIPTION
Closes: https://github.com/fluxcd/website/issues/2493

Adds ArtifactGenerator use cases to the End-to-End guide, covering monorepo decomposition and Helm chart composition from multiple sources.

Happy to Iterate based on your suggestions @matheuscscp @stefanprodan 🙂