### PR TITLE
Adding documentation for CRD categories

### DIFF
--- a/content/en/flux/cheatsheets/crd-resource-categories.md
+++ b/content/en/flux/cheatsheets/crd-resource-categories.md
@@ -1,0 +1,103 @@
+---
+title: "CRD resource categories"
+linkTitle: "CRD Resource Categories"
+description: "How to list and discover Flux resources using kubectl CRD categories."
+weight: 35
+---
+
+Starting with Flux 2.9, all Flux Custom Resource Definitions (CRDs)
+include [Kubernetes resource categories](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#categories)
+that allow you to use `kubectl get` with category selectors to list Flux resources
+across multiple CRD types in a single command.
+
+## Categories
+
+Every Flux CRD is assigned exactly three categories:
+
+| Category | Scope | Description |
+|---|---|---|
+| `all` | Cluster-wide | Includes Flux resources in `kubectl get all` output |
+| `fluxcd` | All Flux CRDs | Lists every Flux custom resource |
+| Controller-specific | Per controller | Lists resources matching a specific Flux CRD category |
+
+The controller-specific categories are:
+
+| Category | Controller | CRDs |
+|---|---|---|
+| `fluxcd-sources` | source-controller, source-watcher | `GitRepository`, `OCIRepository`, `HelmRepository`, `HelmChart`, `Bucket`, `ExternalArtifact`, `ArtifactGenerator` |
+| `fluxcd-appliers` | kustomize-controller, helm-controller | `Kustomization`, `HelmRelease` |
+| `fluxcd-notifications` | notification-controller | `Alert`, `Provider`, `Receiver` |
+| `fluxcd-images` | image-reflector-controller, image-automation-controller | `ImageRepository`, `ImagePolicy`, `ImageUpdateAutomation` |
+
+## Usage examples
+
+### List all Flux resources
+
+To list all Flux custom resources across all namespaces:
+
+```cli
+kubectl get fluxcd -A
+```
+
+### List Flux resources in the default `kubectl get all` output
+
+Flux resources now appear alongside built-in Kubernetes resources when running:
+
+```cli
+kubectl get all -n flux-system
+```
+
+### List resources by controller category
+
+List all source resources:
+
+```cli
+kubectl get fluxcd-sources -A
+```
+
+List all applier resources (Kustomizations and HelmReleases):
+
+```cli
+kubectl get fluxcd-appliers -A
+```
+
+List all notification resources:
+
+```cli
+kubectl get fluxcd-notifications -A
+```
+
+List all image automation resources:
+
+```cli
+kubectl get fluxcd-images -A
+```
+
+### Filter by namespace
+
+List all Flux resources in a specific namespace:
+
+```cli
+kubectl get fluxcd -n flux-system
+```
+
+### Combine with other kubectl options
+
+You can combine category selectors with any `kubectl get` option.
+For example, to get YAML output for all Flux sources:
+
+```cli
+kubectl get fluxcd-sources -A -o yaml
+```
+
+Or to watch for changes to all Flux resources:
+
+```cli
+kubectl get fluxcd -A --watch
+```
+
+{{% alert color="info" title="Tip" %}}
+Using `kubectl get fluxcd` is the quickest way to get an overview of all Flux resources
+in your cluster. It replaces the need to query each CRD type individually
+(e.g. `kubectl get gitrepositories`, `kubectl get kustomizations`, etc.).
+{{% /alert %}}

--- a/content/en/flux/cheatsheets/troubleshooting.md
+++ b/content/en/flux/cheatsheets/troubleshooting.md
@@ -7,6 +7,12 @@ weight: 40
 
 ## Getting basic information
 
+{{% alert color="info" title="Quick overview" %}}
+To quickly list all Flux resources in your cluster, use the `fluxcd` [CRD category](/flux/cheatsheets/crd-resource-categories/):
+`kubectl get fluxcd -A`. You can also use `kubectl get fluxcd-sources -A`
+or `kubectl get fluxcd-appliers -A` to filter by Flux CRD categories.
+{{% /alert %}}
+
 Show all Flux objects that are not ready
 
 ```cli

--- a/content/en/flux/components/_index.md
+++ b/content/en/flux/components/_index.md
@@ -23,6 +23,11 @@ You can use the toolkit to extend Flux, and to build your own systems
 for continuous delivery. The [source-watcher
 guide](../gitops-toolkit/source-watcher/) is a good place to start.
 
+All Flux CRDs are registered with
+[Kubernetes resource categories](/flux/cheatsheets/crd-resource-categories/)
+that allow you to list resources across multiple CRD types with a single `kubectl` command,
+for example `kubectl get fluxcd -A` lists every Flux resource in the cluster.
+
 A reference for each component and API type is linked below.
 
 - [Source Controllers](source/_index.md)


### PR DESCRIPTION
Part of : https://github.com/fluxcd/flux2/issues/5947

 documented the new Flux CRD resource categories

preview link: https://deploy-preview-2592--fluxcd.netlify.app/flux/cheatsheets/crd-resource-categories/

@matheuscscp  Happy to iterate based on your suggestions  🙏