### PR TITLE
Fix broken bitnami-labs references to bitnami

### DIFF
--- a/content/en/flux/guides/sealed-secrets.md
+++ b/content/en/flux/guides/sealed-secrets.md
@@ -6,7 +6,7 @@ weight: 70
 ---
 
 In order to store secrets safely in a public or private Git repository, you can use
-Bitnami's [sealed-secrets controller](https://github.com/bitnami-labs/sealed-secrets)
+Bitnami's [sealed-secrets controller](https://github.com/bitnami/sealed-secrets)
 and encrypt your Kubernetes Secrets into SealedSecrets.
 The sealed secrets can be decrypted only by the controller running in your cluster and
 nobody else can obtain the original secret, even if they have access to the Git repository.
@@ -29,7 +29,7 @@ brew install kubeseal
 ```
 
 For Linux or Windows you can download the kubeseal binary from
-[GitHub](https://github.com/bitnami-labs/sealed-secrets/releases).
+[GitHub](https://github.com/bitnami/sealed-secrets/releases).
 
 ## Deploy sealed-secrets with a HelmRelease
 
@@ -41,7 +41,7 @@ First you have to register the Helm repository where the sealed-secrets chart is
 ```sh
 flux create source helm sealed-secrets \
 --interval=1h \
---url=https://bitnami-labs.github.io/sealed-secrets
+--url=https://bitnami.github.io/sealed-secrets
 ```
 
 With `interval` we configure [source-controller](../components/source/_index.md) to download
@@ -129,7 +129,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h0m0s
-  url: https://bitnami-labs.github.io/sealed-secrets
+  url: https://bitnami.github.io/sealed-secrets
 ```
 
 Helm release manifest:

--- a/content/en/flux/security/best-practices.md
+++ b/content/en/flux/security/best-practices.md
@@ -228,7 +228,7 @@ The recommendations below are based on Flux's latest version.
   <details>
     <summary>Audit Procedure</summary>
     
-    - Check whether the Secret Provider configuration is security hardened. Please seek [SOPS](https://github.com/mozilla/sops) and [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) documentation for how to best implement each solution.
+    - Check whether the Secret Provider configuration is security hardened. Please seek [SOPS](https://github.com/mozilla/sops) and [SealedSecrets](https://github.com/bitnami/sealed-secrets) documentation for how to best implement each solution.
     - When SealedSecrets are employed, pay special attention to the scopes being used.
   </details>
 

--- a/content/en/flux/security/secrets-management.md
+++ b/content/en/flux/security/secrets-management.md
@@ -270,7 +270,7 @@ scenarios are considered.
 
 [kubernetes secrets]: https://kubernetes.io/docs/concepts/configuration/secret/
 [etcd encryption]: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
-[Sealed Secrets]: https://github.com/bitnami-labs/sealed-secrets
+[Sealed Secrets]: https://github.com/bitnami/sealed-secrets
 [SOPS]: https://github.com/mozilla/sops
 [1Password Operator]: https://github.com/1Password/onepassword-operator
 [External Secrets Operator]: https://github.com/external-secrets/external-secrets

--- a/content/en/flux/use-cases/gh-actions-manifest-generation.md
+++ b/content/en/flux/use-cases/gh-actions-manifest-generation.md
@@ -559,7 +559,7 @@ When you write a `Kustomization` to apply this, be sure you are aware of whether
 ```javascript
 # Any Old App Jsonnet example 0.10.1 - manifests/example.jsonnet
 
-local kube = import 'https://github.com/bitnami-labs/kube-libsonnet/raw/73bf12745b86718083df402e89c6c903edd327d2/kube.libsonnet';
+local kube = import 'https://github.com/bitnami/kube-libsonnet/raw/73bf12745b86718083df402e89c6c903edd327d2/kube.libsonnet';
 
 local example = import 'example.libsonnet';
 
@@ -799,7 +799,7 @@ So get ready for _obfuscated nightmare mode_, (which is the name we thoughtfully
 
 // This example uses kube.libsonnet from Bitnami.  There are other
 // Kubernetes libraries available, or write your own!
-local kube = import 'https://github.com/bitnami-labs/kube-libsonnet/raw/73bf12745b86718083df402e89c6c903edd327d2/kube.libsonnet';
+local kube = import 'https://github.com/bitnami/kube-libsonnet/raw/73bf12745b86718083df402e89c6c903edd327d2/kube.libsonnet';
 
 // The declaration below adds configuration to a more verbose base, defined in
 // more detail at the neighbor libsonnet file here:
@@ -859,7 +859,7 @@ Jsonnet objects can also be added to other objects, composing their fields from 
 
 I'm trying to learn Jsonnet as fast as I can, I hope you're still with me and if not, don't worry. Where did all of this programming come from? (And what's a list comprehension?) It really doesn't matter.
 
-The heavy lifting libraries for this example are from [anguslees/kustomize-libsonnet], which implements some basic primitives of Kustomize in Jsonnet. YAML parser is provided by [bitnami/kubecfg][kubecfg yaml parser], and the Jsonnet implementations of Kubernetes primitives by [bitnami-labs/kube-libsonnet].
+The heavy lifting libraries for this example are from [anguslees/kustomize-libsonnet], which implements some basic primitives of Kustomize in Jsonnet. YAML parser is provided by [bitnami/kubecfg][kubecfg yaml parser], and the Jsonnet implementations of Kubernetes primitives by [bitnami/kube-libsonnet].
 
 It is a matter of taste whether you consider from above the first, second, or third example to be better stylistically. It is a matter of taste and circumstances, to put a finer point on it. They each have strengths and weaknesses, depending mostly on whatever changes we will have to make to them next.
 
@@ -1281,7 +1281,7 @@ If you are on GitHub, and are struggling to get started using GitHub Actions, or
 [example 10.2 configmap]: https://github.com/kingdonb/any_old_app/blob/release/0.10.2/manifests/examples/configMap.yaml
 [anguslees/kustomize-libsonnet]: https://github.com/anguslees/kustomize-libsonnet
 [kubecfg yaml parser]: https://github.com/bitnami/kubecfg/blob/master/lib/kubecfg.libsonnet#L25
-[bitnami-labs/kube-libsonnet]: https://github.com/bitnami-labs/kube-libsonnet
+[bitnami/kube-libsonnet]: https://github.com/bitnami/kube-libsonnet
 [example 10.3 jsonnet]: https://github.com/kingdonb/any_old_app/blob/release/0.10.3/manifests/example.jsonnet
 [Manual Gating]: /flagger/usage/webhooks#manual-gating
 [flux create tenant]: /cmd/flux_create_tenant


### PR DESCRIPTION
The bitnami-labs repository has moved, therefore some links return a 404. Using the labs repo causes the sealed-secrets HelmRelease to fail.

Announced here: https://github.com/bitnami/sealed-secrets/issues/1982