### PR TITLE
docs: fix broken external links in security and guides docs

### DIFF
--- a/content/en/flux/cheatsheets/oci-artifacts.md
+++ b/content/en/flux/cheatsheets/oci-artifacts.md
@@ -391,7 +391,7 @@ spec:
 
 {{% alert color="info" title="Cosign Keyless" %}}
 For publicly available OCI artifacts, which are signed using
-the [Cosign Keyless](https://docs.sigstore.dev/cosign/keyless/)
+the [Cosign Keyless](https://docs.sigstore.dev/cosign/signing/overview/)
 method, you can enable the verification by omitting the `.verify.secretRef` field.
 
 Note that keyless verification is an **experimental feature**, using

--- a/content/en/flux/guides/sortable-image-tags.md
+++ b/content/en/flux/guides/sortable-image-tags.md
@@ -189,7 +189,7 @@ spec:
       order: asc
 ```
 
-[circle-ci-env]: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+[circle-ci-env]: https://circleci.com/docs/env-vars/#built-in-environment-variables
 [github-actions-env]: https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
 [travis-env]: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
 [dockerhub-rates]: https://docs.docker.com/docker-hub/billing/faq/#pull-rate-limiting-faqs

--- a/content/en/flux/security/_index.md
+++ b/content/en/flux/security/_index.md
@@ -29,7 +29,7 @@ The Flux CLI and the controllers' images are signed using [Sigstore](https://www
 The container images along with their signatures are published on GitHub Container Registry and Docker Hub.
 
 To verify the authenticity of Flux's container images,
-install [cosign](https://docs.sigstore.dev/cosign/installation/) v2 and run:
+install [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) v2 and run:
 
 ```console
 $ cosign verify ghcr.io/fluxcd/source-controller:v1.0.0 \

--- a/content/en/flux/security/secrets-management.md
+++ b/content/en/flux/security/secrets-management.md
@@ -280,4 +280,4 @@ scenarios are considered.
 [OCI Repositories]: /flux/components/source/ocirepositories/
 [stakater/Reloader]: https://github.com/stakater/Reloader
 [kustomize-secretgenerator]: /flux/components/kustomize/kustomizations/#kustomize-secretgenerator
-[kustomization-secretgenerator]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomizations/#secretgenerator
+[kustomization-secretgenerator]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#secretgenerator


### PR DESCRIPTION
Several documentation links return HTTP 404. This updates each to its current working location:

- `content/en/flux/security/_index.md` (1 link)
- `content/en/flux/guides/sortable-image-tags.md` (1 link)
- `content/en/flux/cheatsheets/oci-artifacts.md` (1 link)
- `content/en/flux/security/secrets-management.md` (1 link)

Docs-only change. Each replacement URL was verified to return HTTP 200.