### PR TITLE
Correcting the location to `interval` value

### DIFF
--- a/content/en/flux/installation/upgrade.md
+++ b/content/en/flux/installation/upgrade.md
@@ -126,7 +126,7 @@ spec:
       name: << inputs.provider.name >>
       namespace: << inputs.provider.namespace >>
      spec:
-      interval: << inputs.provider.interval >>
+      interval: << inputs.interval >>
       url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
       layerSelector:
         mediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"


### PR DESCRIPTION
I copied [this example](https://fluxcd.io/flux/installation/upgrade/#upgrade-with-flux-operator) to my repo, but it failed with this error:

<img width="1240" height="411" alt="Screenshot 2026-07-12 at 19 34 33" src="https://github.com/user-attachments/assets/7a96305c-f08b-4eea-80d3-d9cdb27c1abf" />

There is no value at `inputs.provider.interval`. It should be just `inputs.interval`. After my fix, it works correctly.
