### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:cncf-flux-security@lists.cncf.io
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://fluxcd.io/.well-known/security.txt
+Policy: https://github.com/fluxcd/.github/blob/main/SECURITY.md


### PR DESCRIPTION
## What
Add `/.well-known/security.txt` under `static/` so fluxcd.io serves one.

## Why
`https://fluxcd.io/.well-known/security.txt` returns 404, while `https://fluxcd.io/security/` (200) documents the security team. [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) makes `/.well-known/security.txt` the standard, machine-discoverable pointer to the reporting channel (the `cncf-flux-security` list). Served verbatim from `static/`, future `Expires` per §2.5.5. Signed off per DCO.

I used AI assistance to identify this and draft the file; I verified the live 404 and the reporting channel myself.