### PR TITLE
Update references to CNCF calendar

### DIFF
--- a/hack/import-calendar.py
+++ b/hack/import-calendar.py
@@ -27,7 +27,7 @@ import recurring_ical_events
 import urllib3
 import yaml
 
-CAL_URL = 'https://lists.cncf.io/g/cncf-flux-dev/ics/9524119/1081862612/feed.ics'
+CAL_URL = 'https://webcal.prod.itx.linuxfoundation.org/lfx/a092M00001IfTjDQAV'
 
 TOP_LEVEL_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '..'))


### PR DESCRIPTION
The old cncf-flux-dev calendar is supposed to go away:

https://lists.cncf.io/g/cncf-flux-dev

The new Flux calendar lives on LFX Platform and actually requires login *even less* than the old cncf-flux-dev did, anyone can subscribe totally anonymously as far as I can tell. The docs update reflects the difference.

There is a parallel PR in the community repo that I will link back here when I post it, momentarily.