### PR TITLE
docs: add CEL health-check entries for Application, Certificate, ExternalSecret, ScaledJob

### DIFF
--- a/content/en/flux/cheatsheets/cel-healthchecks.md
+++ b/content/en/flux/cheatsheets/cel-healthchecks.md
@@ -74,6 +74,20 @@ healthCheckExprs:
 
 The items in this library are sorted in alphabetical order.
 
+### `Application`
+
+The `Application` resource from Argo CD reports its health through `status.health.status`
+rather than status conditions, making it a useful non-conditions example. The `has` macro
+guards against the field being absent while the application is still progressing.
+
+```yaml
+healthCheckExprs:
+  - apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    failed: has(status.health) && status.health.status == 'Degraded'
+    current: has(status.health) && status.health.status == 'Healthy'
+```
+
 ### `CephCluster`
 
 The `CephCluster` resource in this example is created by the `rook-ceph-cluster` Flux `HelmRelease`.
@@ -93,6 +107,16 @@ healthCheckExprs:
     kind: CephCluster
     failed: status.ceph.health == 'HEALTH_ERR'
     current: status.ceph.health == 'HEALTH_OK'
+```
+
+### `Certificate`
+
+```yaml
+healthCheckExprs:
+  - apiVersion: cert-manager.io/v1
+    kind: Certificate
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
 ```
 
 ### `Cluster`
@@ -136,6 +160,26 @@ healthCheckExprs:
   - apiVersion: iam.aws.crossplane.io/v1beta1
     kind: Role
     failed: status.conditions.filter(e, e.type == 'Synced').all(e, e.status == 'False' && e.reason == 'ReconcileError')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+```
+
+### `ExternalSecret`
+
+```yaml
+healthCheckExprs:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+```
+
+### `ScaledJob`
+
+```yaml
+healthCheckExprs:
+  - apiVersion: keda.sh/v1alpha1
+    kind: ScaledJob
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
     current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
 ```
 


### PR DESCRIPTION
## Description

Extends the community CEL health-check library in `cel-healthchecks.md` with entries for four commonly-used custom resources, placed in alphabetical order following the existing conventions:

- **Argo CD `Application`** (`argoproj.io/v1alpha1`) — uses `status.health.status`, a useful non-conditions example (the library previously had no `status.health`-based entry).
- **cert-manager `Certificate`** (`cert-manager.io/v1`) — the library had `ClusterIssuer` but not `Certificate`, the most common cert-manager object.
- **External Secrets `ExternalSecret`** (`external-secrets.io/v1beta1`) — complements the existing `ClusterSecretStore` entry.
- **KEDA `ScaledJob`** (`keda.sh/v1alpha1`) — complements the existing `ScaledObject` entry.

## Evidence of correctness

Three of the four entries (`Certificate`, `ExternalSecret`, `ScaledJob`) reuse the exact `status.conditions` `Ready` pattern already validated in the library for `ClusterIssuer`, `ClusterSecretStore`, and `ScaledObject` respectively.

Evaluating each expression against representative resource status (the input passed to a CEL expression is the resource object itself, as in the [CEL Playground](https://playcel.undistro.io/)):

**`Application`** — `has(status.health) && status.health.status == '<X>'`
- `{"status":{"health":{"status":"Healthy"}}}` → `current` = true, `failed` = false ✅
- `{"status":{"health":{"status":"Degraded"}}}` → `current` = false, `failed` = true ✅
- `{"status":{}}` (still progressing, `health` absent) → both false, so Flux keeps waiting ✅ (the `has()` guard prevents a no-such-field error)

**`Certificate` / `ExternalSecret` / `ScaledJob`** — `status.conditions.filter(e, e.type == 'Ready').all(e, e.status == '<X>')`
- `{"status":{"conditions":[{"type":"Ready","status":"True"}]}}` → `current` = true, `failed` = false ✅
- `{"status":{"conditions":[{"type":"Ready","status":"False"}]}}` → `current` = false, `failed` = true ✅

Happy to adjust any of these (e.g. broaden the `Application` `failed` condition to include `Missing`) based on maintainer preference.