### PR TITLE
blog: copy photo subtitle to a visible place

### DIFF
--- a/content/en/blog/2026-07-07-flux-turns-10/index.md
+++ b/content/en/blog/2026-07-07-flux-turns-10/index.md
@@ -101,6 +101,8 @@ We can't capture all of the names and stories, battles and victories in this mea
 
 ![6 Flux Maintainers on-stage at the very first FluxCon: Matheus, Stefan, Tamao, Pinky, Leigh, Kingdon](images/maintainers-crop.png)
 
+*6 Flux Maintainers on-stage at the very first FluxCon: Matheus, Stefan, Tamao, Pinky, Leigh, Kingdon*
+
 Here is a short list of some folks who've made over 20 commits to Flux:
 - @stefanprodan, Stefan Prodan
 - @hiddeco, Hidde Beydals


### PR DESCRIPTION
My university is building a website to motivate students to engage in Competitive Programming and asked ex-competitors for a small paragraph and a link to put on that website showing where the ex-competitors are working now. I thought the 10-year blog post was a good link, so I'm copying the photo subtitle to make it more visible.

Preview:

<img width="946" height="418" alt="Screenshot from 2026-09-02 12-23-28" src="https://github.com/user-attachments/assets/670ca42d-775b-4379-83a8-c6c04ff6dde1" />
