### PR TITLE
docs: Image Automation exclusions, OCI HelmRepository status, controller-runtime alerts

### DIFF
--- a/content/en/flux/cheatsheets/troubleshooting.md
+++ b/content/en/flux/cheatsheets/troubleshooting.md
@@ -38,6 +38,43 @@ See the CLI reference for [`get_sources_all`](/flux/cmd/flux_get_sources_all/).
 ```cli
 kubectl get gitrepositories.source.toolkit.fluxcd.io -A
 kubectl get helmrepositories.source.toolkit.fluxcd.io -A
+
+## OCI HelmRepository Ready column is blank
+
+HTTP `HelmRepository` objects show `Ready=True` and an index artifact.
+**OCI** `HelmRepository` (`spec.type: oci`) often has an empty `status` and a
+blank Ready printer column even when chart pulls succeed. That is current
+source-controller behavior: OCI HelmRepositories may not produce an HTTP-style
+index artifact. Empty status is **not** by itself a failed reconcile.
+
+Verify health via dependents, not the HelmRepository Ready column:
+
+```cli
+flux get sources chart -A
+flux get helmreleases -A
+kubectl get helmcharts.source.toolkit.fluxcd.io -A
+```
+
+If those are Ready and the chart version is what you expect, the OCI source is
+working. Check source-controller logs only when HelmChart / HelmRelease pulls
+fail.
+
+Companion: [source-controller#2135](https://github.com/fluxcd/source-controller/issues/2135).
+
+## Alert and Provider have no status conditions
+
+`Alert` and `Provider` CRs currently do **not** expose Ready / lastSentAt /
+lastError. `kubectl describe alert` will not show the last Telegram (or other
+provider) dispatch error. Use notification-controller logs and Kubernetes
+events:
+
+```cli
+flux logs --kind=alert --all-namespaces --level=error
+kubectl get events -n flux-system --field-selector involvedObject.kind=Alert
+```
+
+Companion: [notification-controller#1371](https://github.com/fluxcd/notification-controller/issues/1371).
+
 ```
 
 Flux CLI (check for Ready=True and Suspend=False)

--- a/content/en/flux/cheatsheets/troubleshooting.md
+++ b/content/en/flux/cheatsheets/troubleshooting.md
@@ -38,11 +38,12 @@ See the CLI reference for [`get_sources_all`](/flux/cmd/flux_get_sources_all/).
 ```cli
 kubectl get gitrepositories.source.toolkit.fluxcd.io -A
 kubectl get helmrepositories.source.toolkit.fluxcd.io -A
+```
 
 ## OCI HelmRepository Ready column is blank
 
 HTTP `HelmRepository` objects show `Ready=True` and an index artifact.
-**OCI** `HelmRepository` (`spec.type: oci`) often has an empty `status` and a
+**OCI** `HelmRepository` (`spec.type: oci`) has an empty `status` by design and a
 blank Ready printer column even when chart pulls succeed. That is current
 source-controller behavior: OCI HelmRepositories may not produce an HTTP-style
 index artifact. Empty status is **not** by itself a failed reconcile.
@@ -63,19 +64,16 @@ Companion: [source-controller#2135](https://github.com/fluxcd/source-controller/
 
 ## Alert and Provider have no status conditions
 
-`Alert` and `Provider` CRs currently do **not** expose Ready / lastSentAt /
-lastError. `kubectl describe alert` will not show the last Telegram (or other
-provider) dispatch error. Use notification-controller logs and Kubernetes
-events:
+`Alert` and `Provider` CRs do **not** have a status field.
+`kubectl describe alert` will not show information about recent notifications.
+Use notification-controller logs and Kubernetes events:
 
 ```cli
-flux logs --kind=alert --all-namespaces --level=error
+flux logs --kind=Alert --all-namespaces --level=error
 kubectl get events -n flux-system --field-selector involvedObject.kind=Alert
 ```
 
 Companion: [notification-controller#1371](https://github.com/fluxcd/notification-controller/issues/1371).
-
-```
 
 Flux CLI (check for Ready=True and Suspend=False)
 

--- a/content/en/flux/monitoring/alerts.md
+++ b/content/en/flux/monitoring/alerts.md
@@ -88,6 +88,43 @@ flux get alerts
 
 Multiple alerts can be used to send notifications to different channels or Slack workspaces.
 
+## Exclude noisy Image Automation events
+
+Image automation (`ImageRepository` / `ImagePolicy`) emits **expected** error
+events on cold start: after image-reflector-controller restarts, the in-memory
+tag database is empty until scans refill. Those messages (`no tags in database`,
+`version list argument cannot be empty`) are safe to exclude from chat
+providers. Overly broad regexes can hide real registry outages — tune carefully.
+Exclusion is **message-based**; wording can change across controller versions.
+
+```yaml
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  providerRef:
+    name: chat
+  eventSeverity: error
+  eventSources:
+    - kind: ImageRepository
+      name: '*'
+    - kind: ImagePolicy
+      name: '*'
+  exclusionList:
+    - "no tags in database"
+    - "version list argument cannot be empty"
+    # Optional: short-lived registry / DNS noise. Tune carefully.
+    # - "lookup .*: (i/o timeout|no such host|server misbehaving)"
+    # - "connection refused"
+```
+
+See [Alert event exclusion](/flux/components/notification/alerts/#event-exclusion).
+Related controller work: [image-reflector-controller#930](https://github.com/fluxcd/image-reflector-controller/issues/930),
+[notification-controller#1370](https://github.com/fluxcd/notification-controller/issues/1370).
+
+
 The event severity can be set to `info` or `error`.
 When the severity is set to `error`, the kustomize controller will alert on any error
 encountered during the reconciliation process.

--- a/content/en/flux/monitoring/metrics.md
+++ b/content/en/flux/monitoring/metrics.md
@@ -71,6 +71,48 @@ controller_runtime_reconcile_total{controller, result}
 In addition, many other Go runtime and [controller-runtime
 metrics][controller-runtime-metrics] are also exported.
 
+### Alerting on controller-runtime reconcile errors
+
+Operators who scrape only the Flux `PodMonitor` (`http-prom` port, label
+`app.kubernetes.io/part-of: flux`) get standard controller-runtime series such
+as `controller_runtime_reconcile_errors_total` and
+`controller_runtime_reconcile_total{result="error"}`. That path does **not**
+require kube-state-metrics / `gotk_resource_info`. Use it as a high-signal
+complement to [notification-controller](/flux/monitoring/alerts/) events.
+
+Example PrometheusRule (adjust `for` / thresholds):
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux-controller-reconcile-errors
+  namespace: flux-system
+spec:
+  groups:
+    - name: flux-controller-runtime
+      rules:
+        - alert: FluxReconcileErrors
+          expr: |
+            sum by (controller, namespace) (
+              rate(controller_runtime_reconcile_errors_total{
+                controller=~"imageupdateautomation|imagerepository|imagepolicy|helmrelease|kustomization"
+              }[10m])
+            ) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Flux {{ $labels.controller }} reconcile errors"
+            description: >-
+              controller-runtime is reporting reconcile errors for
+              {{ $labels.controller }} in {{ $labels.namespace }}.
+              Check `flux get all -A --status-selector ready=false` and controller logs.
+```
+
+This is complementary to notification-controller chat alerts and to
+`gotk_resource_info` readiness alerts where kube-state-metrics is configured.
+
 ## Resource metrics
 
 Metrics for the Flux custom resources can be used to monitor the deployment of


### PR DESCRIPTION
Fixes #2644. Fixes #2643. Fixes #2640. Operator docs for Alert exclusionList, OCI HelmRepository empty status, and controller_runtime_reconcile_errors_total alerts.